### PR TITLE
Add CombinedEyeLid

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For this mod to work, you'll need to be using an avatar with the correct paramet
 |`EyesY`|Gaze Direction Y|Combined|
 |`LeftEyeLid`|Eyelid Open|Left|
 |`RightEyeLid`|Eyelid Open|Right|
+|`CombinedEyeLid`|Eyelid Open|Combined|
 |`EyesWiden`|Eye Widen|Combined|
 |`EyesDilation`|Pupil Dilation|Combined|
 |`EyesSqueeze`|Eyelid Squeeze|Combined|

--- a/VRCFaceTracking/Params/EyeTrackingParams.cs
+++ b/VRCFaceTracking/Params/EyeTrackingParams.cs
@@ -24,9 +24,11 @@ namespace VRCFaceTracking.Params
 
             new FloatEyeParameter(v2 => v2.Left, "LeftEyeLid", true),
             new FloatEyeParameter(v2 => v2.Right, "RightEyeLid", true),
+            new FloatEyeParameter(v2 => (v2.Left + v2.Right)/2, "CombinedEyeLid", true),
             
             new BoolEyeParameter(v2 => v2.Left < 0.5f, "LeftEyeLid"),
             new BoolEyeParameter(v2 => v2.Right < 0.5f, "RightEyeLid"),
+            new BoolEyeParameter(v2 => (v2.Left + v2.Right)/2 < 0.5f, "CombinedEyeLid"),
             
             new FloatEyeParameter(v2 =>
             {


### PR DESCRIPTION
This PR adds support for CombinedEyeLid properties. The main reason I added this, is because I was working with an avatar that used textures for it's eyes and I wanted to save parameter storage, so instead of using both Left and Right Eyelid as conditions in the animator controller, I added CombinedEyeLid. There's both the float and bool parameter support, just like the current Left and Right Eyelid parameters.

The math is just `(LeftEyeLid + RightEyeLid)/2` and if it's a bool parameter, it adds `< 0.5f`. There is native CombinedEyeLid data with the v2 eye data, but I can't get it to work for me (I think an HMD issue) and this would mathematically be the same.

File Changes:
+ `Params/EyeTrackingParams.cs`
  + Added "CombinedEyeLid" as a `FloatEyeParameter`
    + This gets v2 data to add both Left and Right Eyelid data, then divide by two.
    + See math above for more info.
  + Added "CombinedEyeLid" as `BoolEyeParameter`
    + This gets v2 data to add both Left and Right Eyelid data, divide by two, then check to see if the output is less than `0.5f`
    + See math above for more info.

Built with dnSpy, because for whatever reason, if I built through VS or Rider, VRChat would just freeze when trying to load the mod. Testing showed that the FloatEyeParameter seemed to work fine, so I'm sure the BoolEyeParameter (untested) should work too. If you'd like me to attach my build, I'll add it in a comment.