### PR TITLE
Implement combined left/right params

### DIFF
--- a/VRCFaceTracking/Params/Lip/LipShapeConversion.cs
+++ b/VRCFaceTracking/Params/Lip/LipShapeConversion.cs
@@ -3,7 +3,13 @@ using ViveSR.anipal.Lip;
 
 namespace VRCFaceTracking.Params.Lip
 {
-    public class PositiveNegativeShape
+
+    public interface ICombinedShape
+    {
+        float GetBlendedLipShape(Dictionary<LipShape_v2, float> inputMap);
+    }
+
+    public class PositiveNegativeShape : ICombinedShape
     {
         private readonly LipShape_v2 _positiveShape, _negativeShape;
         private float _positiveCache, _negativeCache;
@@ -21,4 +27,42 @@ namespace VRCFaceTracking.Params.Lip
             return _positiveCache + _negativeCache;
         }
     }
+
+    public class PositiveNegativeAveragedShape : ICombinedShape
+    {
+        private readonly LipShape_v2[] _positiveShapes, _negativeShapes;
+        private float[] _positiveCache, _negativeCache;
+        private float _positiveCount, _negativeCount;
+
+        public PositiveNegativeAveragedShape(LipShape_v2[] positiveShapes, LipShape_v2[] negativeShapes)
+        {
+            _positiveShapes = positiveShapes;
+            _negativeShapes = negativeShapes;
+            _positiveCache = new float[positiveShapes.Length];
+            _negativeCache = new float[negativeShapes.Length];
+            _positiveCount = (float)positiveShapes.Length;
+            _negativeCount = (float)negativeShapes.Length;
+        }
+
+        public float GetBlendedLipShape(Dictionary<LipShape_v2, float> inputMap)
+        {
+
+            float positive = 0;
+            float negative = 0;
+            for (int i = 0; i < _positiveCount; i++) {
+                if (inputMap.TryGetValue(_positiveShapes[i], out var positiveResult))
+                    _positiveCache[i] = positiveResult;
+                positive += _positiveCache[i];
+            }
+
+            for (int i = 0; i < _negativeCount; i++) {
+                if (inputMap.TryGetValue(_negativeShapes[i], out var negativeResult))
+                    _negativeCache[i] = negativeResult * -1;
+                negative += _negativeCache[i];
+            }
+
+            return (positive / _positiveCount) + (negative / _negativeCount);
+        }
+    }
+
 }

--- a/VRCFaceTracking/Params/Lip/LipShapeConversion.cs
+++ b/VRCFaceTracking/Params/Lip/LipShapeConversion.cs
@@ -31,8 +31,8 @@ namespace VRCFaceTracking.Params.Lip
     public class PositiveNegativeAveragedShape : ICombinedShape
     {
         private readonly LipShape_v2[] _positiveShapes, _negativeShapes;
-        private float[] _positiveCache, _negativeCache;
-        private float _positiveCount, _negativeCount;
+        private readonly float[] _positiveCache, _negativeCache;
+        private readonly int _positiveCount, _negativeCount;
 
         public PositiveNegativeAveragedShape(LipShape_v2[] positiveShapes, LipShape_v2[] negativeShapes)
         {
@@ -40,13 +40,12 @@ namespace VRCFaceTracking.Params.Lip
             _negativeShapes = negativeShapes;
             _positiveCache = new float[positiveShapes.Length];
             _negativeCache = new float[negativeShapes.Length];
-            _positiveCount = (float)positiveShapes.Length;
-            _negativeCount = (float)negativeShapes.Length;
+            _positiveCount = positiveShapes.Length;
+            _negativeCount = negativeShapes.Length;
         }
 
         public float GetBlendedLipShape(Dictionary<LipShape_v2, float> inputMap)
         {
-
             float positive = 0;
             float negative = 0;
             for (int i = 0; i < _positiveCount; i++) {

--- a/VRCFaceTracking/Params/Lip/LipShapeMerger.cs
+++ b/VRCFaceTracking/Params/Lip/LipShapeMerger.cs
@@ -8,14 +8,15 @@ namespace VRCFaceTracking.Params.LipMerging
 {
     public static class LipShapeMerger
     {
-        private static readonly Dictionary<string, PositiveNegativeShape> MergedShapes =
-            new Dictionary<string, PositiveNegativeShape>
+        private static readonly Dictionary<string, ICombinedShape> MergedShapes =
+            new Dictionary<string, ICombinedShape>
             {
                 {"JawX", new PositiveNegativeShape(LipShape_v2.JawRight, LipShape_v2.JawLeft)},
                 {"MouthUpper", new PositiveNegativeShape(LipShape_v2.MouthUpperRight, LipShape_v2.MouthUpperLeft)},
                 {"MouthLower", new PositiveNegativeShape(LipShape_v2.MouthLowerRight, LipShape_v2.MouthLowerLeft)},
                 {"SmileSadRight", new PositiveNegativeShape(LipShape_v2.MouthSmileRight, LipShape_v2.MouthSadRight)},
                 {"SmileSadLeft", new PositiveNegativeShape(LipShape_v2.MouthSmileLeft, LipShape_v2.MouthSadLeft)},
+                {"SmileSad", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthSmileLeft, LipShape_v2.MouthSmileRight}, new LipShape_v2[]{LipShape_v2.MouthSadLeft, LipShape_v2.MouthSadRight})},
                 {"TongueY", new PositiveNegativeShape(LipShape_v2.TongueUp, LipShape_v2.TongueDown)},
                 {"TongueX", new PositiveNegativeShape(LipShape_v2.TongueRight, LipShape_v2.TongueLeft)},
                 {"PuffSuckRight", new PositiveNegativeShape(LipShape_v2.CheekPuffRight, LipShape_v2.CheekSuck)},
@@ -25,6 +26,7 @@ namespace VRCFaceTracking.Params.LipMerging
 
                 //JawOpen based params
                 {"JawOpenApe", new PositiveNegativeShape(LipShape_v2.JawOpen, LipShape_v2.MouthApeShape)},
+                {"JawOpenPuff", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.JawOpen}, new LipShape_v2[]{LipShape_v2.CheekPuffLeft, LipShape_v2.CheekPuffRight})},
                 {"JawOpenPuffRight", new PositiveNegativeShape(LipShape_v2.JawOpen, LipShape_v2.CheekPuffRight)},
                 {"JawOpenPuffLeft", new PositiveNegativeShape(LipShape_v2.JawOpen, LipShape_v2.CheekPuffLeft)},
                 {"JawOpenSuck", new PositiveNegativeShape(LipShape_v2.JawOpen, LipShape_v2.CheekSuck)},
@@ -44,6 +46,15 @@ namespace VRCFaceTracking.Params.LipMerging
                 {"MouthUpperUpLeftPout", new PositiveNegativeShape(LipShape_v2.MouthUpperUpLeft, LipShape_v2.MouthPout)},
                 {"MouthUpperUpLeftOverlay", new PositiveNegativeShape(LipShape_v2.MouthUpperUpLeft, LipShape_v2.MouthLowerOverlay)},
 
+                // MouthUpperUp Left+Right base params
+                {"MouthUpperUpUpperInside", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthUpperUpLeft, LipShape_v2.MouthUpperUpRight}, new LipShape_v2[]{LipShape_v2.MouthUpperInside })},
+                {"MouthUpperUpPuff", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthUpperUpLeft, LipShape_v2.MouthUpperUpRight}, new LipShape_v2[]{LipShape_v2.CheekPuffLeft, LipShape_v2.CheekPuffRight})},
+                {"MouthUpperUpPuffLeft", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthUpperUpLeft, LipShape_v2.MouthUpperUpRight}, new LipShape_v2[]{LipShape_v2.CheekPuffLeft})},
+                {"MouthUpperUpPuffRight", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthUpperUpLeft, LipShape_v2.MouthUpperUpRight}, new LipShape_v2[]{LipShape_v2.CheekPuffRight})},
+                {"MouthUpperUpApe", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthUpperUpLeft, LipShape_v2.MouthUpperUpRight}, new LipShape_v2[]{LipShape_v2.MouthApeShape})},
+                {"MouthUpperUpPout", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthUpperUpLeft, LipShape_v2.MouthUpperUpRight}, new LipShape_v2[]{LipShape_v2.MouthPout})},
+                {"MouthUpperUpOverlay", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthUpperUpLeft, LipShape_v2.MouthUpperUpRight}, new LipShape_v2[]{LipShape_v2.MouthLowerOverlay})},
+
                 //MouthLowerDownRight based params
                 {"MouthLowerDownRightLowerInside", new PositiveNegativeShape(LipShape_v2.MouthLowerDownRight, LipShape_v2.MouthLowerInside)},
                 {"MouthLowerDownRightPuffRight", new PositiveNegativeShape(LipShape_v2.MouthLowerDownRight, LipShape_v2.CheekPuffRight)},
@@ -58,6 +69,15 @@ namespace VRCFaceTracking.Params.LipMerging
                 {"MouthLowerDownLeftPout", new PositiveNegativeShape(LipShape_v2.MouthLowerDownLeft, LipShape_v2.MouthPout)},
                 {"MouthLowerDownLeftOverlay", new PositiveNegativeShape(LipShape_v2.MouthLowerDownLeft, LipShape_v2.MouthLowerOverlay)},
 
+                // MouthLowerDown Left+Right base params
+                {"MouthLowerDownLowerInside", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthLowerDownLeft, LipShape_v2.MouthLowerDownRight}, new LipShape_v2[]{LipShape_v2.MouthLowerInside})},
+                {"MouthLowerDownPuff", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthLowerDownLeft, LipShape_v2.MouthLowerDownRight}, new LipShape_v2[]{LipShape_v2.CheekPuffLeft, LipShape_v2.CheekPuffRight})},
+                {"MouthLowerDownPuffLeft", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthLowerDownLeft, LipShape_v2.MouthLowerDownRight}, new LipShape_v2[]{LipShape_v2.CheekPuffLeft})},
+                {"MouthLowerDownPuffRight", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthLowerDownLeft, LipShape_v2.MouthLowerDownRight}, new LipShape_v2[]{LipShape_v2.CheekPuffRight})},
+                {"MouthLowerDownApe", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthLowerDownLeft, LipShape_v2.MouthLowerDownRight}, new LipShape_v2[]{LipShape_v2.MouthApeShape})},
+                {"MouthLowerDownPout", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthLowerDownLeft, LipShape_v2.MouthLowerDownRight}, new LipShape_v2[]{LipShape_v2.MouthPout})},
+                {"MouthLowerDownOverlay", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthLowerDownLeft, LipShape_v2.MouthLowerDownRight}, new LipShape_v2[]{LipShape_v2.MouthLowerOverlay})},
+
                 //SmileRight based params; Recommend using these if you already have SmileSadLeft setup!
                 {"SmileRightUpperOverturn", new PositiveNegativeShape(LipShape_v2.MouthSmileRight, LipShape_v2.MouthUpperOverturn)},
                 {"SmileRightLowerOverturn", new PositiveNegativeShape(LipShape_v2.MouthSmileRight, LipShape_v2.MouthLowerOverturn)},
@@ -71,6 +91,13 @@ namespace VRCFaceTracking.Params.LipMerging
                 {"SmileLeftApe", new PositiveNegativeShape(LipShape_v2.MouthSmileLeft, LipShape_v2.MouthApeShape)},
                 {"SmileLeftOverlay", new PositiveNegativeShape(LipShape_v2.MouthSmileLeft, LipShape_v2.MouthLowerOverlay)},
                 {"SmileLeftPout", new PositiveNegativeShape(LipShape_v2.MouthSmileLeft, LipShape_v2.MouthPout)},
+
+                {"SmileUpperOverturn", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthSmileLeft, LipShape_v2.MouthSmileRight}, new LipShape_v2[]{LipShape_v2.MouthUpperOverturn})},
+                {"SmileLowerOverturn", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthSmileLeft, LipShape_v2.MouthSmileRight}, new LipShape_v2[]{LipShape_v2.MouthLowerOverturn})},
+                {"SmileApe", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthSmileLeft, LipShape_v2.MouthSmileRight}, new LipShape_v2[]{LipShape_v2.MouthApeShape})},
+                {"SmileOverlay", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthSmileLeft, LipShape_v2.MouthSmileRight}, new LipShape_v2[]{LipShape_v2.MouthLowerOverlay})},
+                {"SmilePout", new PositiveNegativeAveragedShape(new LipShape_v2[]{LipShape_v2.MouthSmileLeft, LipShape_v2.MouthSmileRight}, new LipShape_v2[]{LipShape_v2.MouthPout})},
+
             };
         
         // Make a list called LipParameters containing the results from both GetOptimizedLipParameters and GetAllLipParameters


### PR DESCRIPTION
Many people seem to be using only 1 side of the combined params to power both sides, which isnt ideal for some params. This PR creates new combined params that average the left and right side for these, which should give more consistent resullts across different users. Its possible taking the biggest param (math.max) would be better than taking the avereage for some of these

There is some similar code implemented in #72 for combining/averaging shapes also.