### PR TITLE
GitHub Actions workflow for automatic binary builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+    types: [ opened, edited ]
+
+jobs:
+  build-dotnet-framework:
+    runs-on: windows-latest
+    name: .NET Framework 4.7.2
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Set up NuGet
+        uses: NuGet/setup-nuget@v1.0.5
+
+      - name: Restore NuGet packages
+        run: |
+          nuget restore VRCFaceTracking.sln
+
+      - name: Build solution
+        run: |
+          $MS_BUILD_PATH = Split-Path (& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\amd64\MSBuild.exe | Select-Object -First 1) -Parent
+          $env:PATH = $MS_BUILD_PATH + ';' + $env:PATH
+
+          foreach ($config in 'Debug', 'Release') {
+            Write-Host "Building $config";
+            msbuild -v:m -m -restore -t:Build -p:Configuration=$config -p:TargetFramework=net472 VRCFaceTracking/VRCFaceTracking.csproj
+          }
+
+      - name: Capture version
+        id: versioning
+        run: |
+          echo "::set-output name=VERSION::$(Get-Date -Format "yyyy.MM.dd").$(git rev-parse --short HEAD)"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: VRCFaceTracking_dev_${{ steps.versioning.outputs.VERSION }}
+          path: VRCFaceTracking/bin/*


### PR DESCRIPTION
This is a GitHub Action that triggers on new pushes and pull requests.
It builds the OSC app in both Debug and Release modes, and uploads the result as an artifact.

The commit gets marked with a tick or cross based on whether the build succeeds, so you can check the logs if something fails.
![image](https://user-images.githubusercontent.com/8049998/155874510-acfb2d7f-2611-482e-9b3d-2d2c4eb167be.png)

The artifact is downloadable, so it gives quick access to a debug and release exe & pdb on each commit.
![image](https://user-images.githubusercontent.com/8049998/155874524-2b9822ac-6542-469a-88be-24f9549aa58a.png)

Doesn't handle the example module since that depends on the mod, but can be adjusted to target another csproj or the sln if it gets updated.