### PR TITLE
Adding error message when loading an external module fails

### DIFF
--- a/VRCFaceTracking/UnifiedLibManager.cs
+++ b/VRCFaceTracking/UnifiedLibManager.cs
@@ -111,7 +111,17 @@ namespace VRCFaceTracking
             var trackingModules = Assembly.GetExecutingAssembly().GetTypes()
                 .Where(type => type.GetInterfaces().Contains(typeof(ITrackingModule)));
 
-            trackingModules = trackingModules.Union(LoadExternalModules());
+            try 
+            {
+                trackingModules = trackingModules.Union(LoadExternalModules());
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                foreach (var loaderException in e.LoaderExceptions)
+                {
+                    Logger.Error("LoaderException: " + loaderException.Message);
+                }
+            }
 
             foreach (var module in trackingModules)
             {


### PR DESCRIPTION
Was quite handy to find out why VRCFTVarjoModule wasn't working (the recent Interface changes)