### PR TITLE
Moving try/catch so that it's actually useful.

### DIFF
--- a/VRCFaceTracking/UnifiedLibManager.cs
+++ b/VRCFaceTracking/UnifiedLibManager.cs
@@ -91,12 +91,12 @@ namespace VRCFaceTracking
             var dlls = Directory.GetFiles(path, "*.dll");
             foreach (var dll in dlls)
             {
-                Logger.Msg("Loading "+dll);
-                var loadedModule = Assembly.LoadFrom(dll);
-                
+                Logger.Msg("Loading " + dll);
+
                 Type module = null;
                 try 
                 {
+                    var loadedModule = Assembly.LoadFrom(dll);
                     // Get the first class that implements ExtTrackingModule
                     module = loadedModule.GetTypes().FirstOrDefault(t => t.IsSubclassOf(typeof(ExtTrackingModule)));
                 }

--- a/VRCFaceTracking/UnifiedLibManager.cs
+++ b/VRCFaceTracking/UnifiedLibManager.cs
@@ -92,10 +92,13 @@ namespace VRCFaceTracking
             foreach (var dll in dlls)
             {
                 Logger.Msg("Loading "+dll);
-                Assembly loadedModule = null;
+                var loadedModule = Assembly.LoadFrom(dll);
+                
+                Type module = null;
                 try 
                 {
-                    loadedModule = Assembly.LoadFrom(dll);
+                    // Get the first class that implements ExtTrackingModule
+                    module = loadedModule.GetTypes().FirstOrDefault(t => t.IsSubclassOf(typeof(ExtTrackingModule)));
                 }
                 catch (ReflectionTypeLoadException e)
                 {
@@ -106,9 +109,6 @@ namespace VRCFaceTracking
                     Logger.Error("Exception loading " + dll + ". Skipping.");
                     continue;
                 }
-                
-                // Get the first class that implements ExtTrackingModule
-                var module = loadedModule.GetTypes().FirstOrDefault(t => t.IsSubclassOf(typeof(ExtTrackingModule)));
                 if (module != null)
                 {
                     returnList.Add(module);


### PR DESCRIPTION
Turns out that the function throwing the reflection exception was GetTypes, not LoadFrom