### PR TITLE
Add EyeTrackingActive and LipTrackingActive parameters

### DIFF
--- a/VRCFaceTracking/Params/Eye/EyeTrackingParams.cs
+++ b/VRCFaceTracking/Params/Eye/EyeTrackingParams.cs
@@ -169,6 +169,12 @@ namespace VRCFaceTracking.Params.Eye
             new BoolParameter(v2 => v2.Combined.Squeeze > 0, "EyesSqueezeToggle"),
 
             #endregion
+
+            #region Status
+
+            new BoolParameter(v2 => UnifiedLibManager.EyeStatus.Equals(ModuleState.Active), "EyeTrackingActive"),
+
+            #endregion
         };
 
         // Brain Hurty

--- a/VRCFaceTracking/Params/Lip/LipShapeMerger.cs
+++ b/VRCFaceTracking/Params/Lip/LipShapeMerger.cs
@@ -125,9 +125,9 @@ namespace VRCFaceTracking.Params.LipMerging
                 {"TongueSteps", new PositiveNegativeShape(LipShape_v2.TongueLongStep1, LipShape_v2.TongueLongStep2, true)},
             };
         
-        // Make a list called LipParameters containing the results from both GetOptimizedLipParameters and GetAllLipParameters
-        public static readonly List<EParam> AllLipParameters =
-            new List<EParam>(GetAllLipShapes().Union(GetOptimizedLipParameters()));
+        // Make a list called LipParameters containing the results from both GetOptimizedLipParameters and GetAllLipParameters, and add GetLipActivatedStatus
+        public static readonly List<IParameter> AllLipParameters =
+            new List<IParameter>(GetAllLipShapes().Union(GetOptimizedLipParameters()).Union(GetLipActivatedStatus()));
 
         public static bool IsLipShapeName(string name) => MergedShapes.ContainsKey(name) || Enum.TryParse(name, out LipShape_v2 shape);
         
@@ -139,5 +139,10 @@ namespace VRCFaceTracking.Params.LipMerging
             ((LipShape_v2[]) Enum.GetValues(typeof(LipShape_v2))).ToList().Select(shape =>
                 new EParam((eye, lip) => lip.LatestShapes[(int)shape],
                     shape.ToString(), 0.0f));
+
+        private static IEnumerable<IParameter> GetLipActivatedStatus() => new List<IParameter>
+        {
+            new BoolParameter(v2 => UnifiedLibManager.LipStatus.Equals(ModuleState.Active), "LipTrackingActive"),
+        };
     }
 }

--- a/VRCFaceTracking/UnifiedTrackingData.cs
+++ b/VRCFaceTracking/UnifiedTrackingData.cs
@@ -45,8 +45,6 @@ namespace VRCFaceTracking
         public float EyesDilation;
         private float _maxDilation, _minDilation;
 
-        public bool EyesEnabled;
-
         public void UpdateData(EyeData_v2 eyeData)
         {
             float dilation = 0;
@@ -99,8 +97,6 @@ namespace VRCFaceTracking
         public bool SupportsImage;
 
         public float[] LatestShapes = new float[SRanipal_Lip_v2.WeightingCount];
-
-        public bool LipsEnabled;
 
         public void UpdateData(LipData_v2 lipData)
         {

--- a/VRCFaceTracking/UnifiedTrackingData.cs
+++ b/VRCFaceTracking/UnifiedTrackingData.cs
@@ -45,6 +45,7 @@ namespace VRCFaceTracking
         public float EyesDilation;
         private float _maxDilation, _minDilation;
 
+        public bool EyesEnabled;
 
         public void UpdateData(EyeData_v2 eyeData)
         {
@@ -98,6 +99,8 @@ namespace VRCFaceTracking
         public bool SupportsImage;
 
         public float[] LatestShapes = new float[SRanipal_Lip_v2.WeightingCount];
+
+        public bool LipsEnabled;
 
         public void UpdateData(LipData_v2 lipData)
         {


### PR DESCRIPTION
These are bool parameters that are set true when the respective type of tracking is active. This allows avatars to detect when tracking is available for use and to react appropriately.

I've tested these with a Vive Pro Eye and the Vive Face Tracker, it accurately detects when the lip tracker is not enabled/tracking as well as turns on/off as appropriate when the hardware isn't present.

I've only added the functionality for one avatar to the eyes to enable/disable tracking with the new parameter, but it worked flawlessly along with an override bool toggle in the expressions menu.

Challenges:
- The VRCFT application does not seem to be able to detect if the face tracker is unplugged and does not set the parameter to false
- Any update that adds new parameters will require users to flush their OSC\usr_*\Avatars folder unless some other code is added for VRCFT to know those json files are stale, but in practice anyone using this should already know to do this when adding new parameters to their avatar (is this documented on the wiki?)
- The parameters should be added to the wiki if the PR is merged