### PR TITLE
Custom OSC port/IP information display and built-in help message

### DIFF
--- a/VRCFaceTracking/ArgsHandler.cs
+++ b/VRCFaceTracking/ArgsHandler.cs
@@ -28,24 +28,18 @@ namespace VRCFaceTracking
                         break;
                     }
 
-                    if (!int.TryParse(oscConfig[0], out SendPort))
+                    
+                    int parsedIntSP;
+                    if (int.TryParse(oscConfig[0], out parsedIntSP))
                     {
-                        Logger.Error("Invalid OSC OutPort: " + oscConfig[0]);
-                        break;
+                        SendPort = parsedIntSP;
+                        Logger.Msg("Loaded custom OSC OutPort value, " + SendPort);
                     }
                     else
                     {
-                        int parsedIntSP;
-                        if (int.TryParse(oscConfig[0], out parsedIntSP))
-                        {
-                            SendPort = parsedIntSP;
-                            Logger.Msg("Loaded custom OSC OutPort value, " + SendPort);
-                        }
-                        else
-                        {
-                            Logger.Error("Malformed OSC OutPort value, please ensure you set a number");
-                        }
+                        Logger.Error("Malformed OSC OutPort value" + oscConfig[0] + ", please ensure you set a number");
                     }
+        
 
                     if (!new Regex("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$").IsMatch(oscConfig[1]))
                     {
@@ -57,25 +51,18 @@ namespace VRCFaceTracking
                         IP = oscConfig[1];
                     }
                     
-                    if (!int.TryParse(oscConfig[2], out RecievePort))
+                    int parsedIntRP;
+                    if (int.TryParse(oscConfig[2], out parsedIntRP))
                     {
-                        Logger.Error("Invalid OSC InPort: " + oscConfig[2]);
-                        break;
+                        RecievePort = parsedIntRP;
+                        Logger.Msg("Loaded custom OSC RecievePort value, " + RecievePort);
                     }
                     else
                     {
-                        int parsedIntRP;
-                        if (int.TryParse(oscConfig[2], out parsedIntRP))
-                        {
-                            RecievePort = parsedIntRP;
-                            Logger.Msg("Loaded custom OSC RecievePort value, " + RecievePort);
-                        }
-                        else
-                        {
-                            Logger.Error("Malformed OSC RecievePort value, please ensure you set a number");
-                        }
+                        Logger.Error("Malformed OSC RecievePort value " + oscConfig[2] + ", please ensure you set a number");
                     }
-        }
+            
+                }
             }
 
             return (SendPort, IP, RecievePort);

--- a/VRCFaceTracking/ArgsHandler.cs
+++ b/VRCFaceTracking/ArgsHandler.cs
@@ -5,40 +5,77 @@ namespace VRCFaceTracking
 {
     public static class ArgsHandler
     {
+        
         public static (int SendPort, string IP, int RecievePort) HandleArgs()
         {
+            Logger.Msg("Loading Defaults");
             (int SendPort, string IP, int RecievePort) = (9000, "127.0.0.1", 9001);
-            
+
             foreach (var arg in Environment.GetCommandLineArgs())
             {
+                if ((arg.StartsWith("--help")) || (arg.StartsWith("--options")))
+                {
+                   Logger.Msg("To set custom OSC port/IP config please use the following");
+                   Logger.Msg("--osc=<OutPort>:<IP>:<InPort>");
+                }
                 if (arg.StartsWith("--osc="))
                 {
+                    Logger.Msg("Loading OSC config Args");
                     var oscConfig = arg.Remove(0, 6).Split(':');
                     if (oscConfig.Length < 3)
                     {
-                        Console.WriteLine("Invalid OSC config: " + arg +"\nExpected format: --osc=<OutPort>:<IP>:<InPort>");
+                        Logger.Error("Invalid OSC config: " + arg +"\nExpected format: --osc=<OutPort>:<IP>:<InPort>");
                         break;
                     }
 
                     if (!int.TryParse(oscConfig[0], out SendPort))
                     {
-                        Console.WriteLine("Invalid OSC OutPort: " + oscConfig[0]);
+                        Logger.Error("Invalid OSC OutPort: " + oscConfig[0]);
                         break;
                     }
-                    
+                    else
+                    {
+                        int parsedIntSP;
+                        if (int.TryParse(oscConfig[0], out parsedIntSP))
+                        {
+                            SendPort = parsedIntSP;
+                            Logger.Msg("Loaded custom OSC OutPort value, " + SendPort);
+                        }
+                        else
+                        {
+                            Logger.Error("Malformed OSC OutPort value, please ensure you set a number");
+                        }
+                    }
+
                     if (!new Regex("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$").IsMatch(oscConfig[1]))
                     {
-                        Console.WriteLine("Invalid OSC IP: " + oscConfig[1]);
+                        Logger.Error("Invalid OSC IP: " + oscConfig[1]);
                         break;
-                    } 
-                    IP = oscConfig[1];
+                    }
+                    else
+                    {
+                        IP = oscConfig[1];
+                    }
                     
                     if (!int.TryParse(oscConfig[2], out RecievePort))
                     {
-                        Console.WriteLine("Invalid OSC InPort: " + oscConfig[2]);
+                        Logger.Error("Invalid OSC InPort: " + oscConfig[2]);
                         break;
                     }
-                }
+                    else
+                    {
+                        int parsedIntRP;
+                        if (int.TryParse(oscConfig[2], out parsedIntRP))
+                        {
+                            RecievePort = parsedIntRP;
+                            Logger.Msg("Loaded custom OSC RecievePort value, " + RecievePort);
+                        }
+                        else
+                        {
+                            Logger.Error("Malformed OSC RecievePort value, please ensure you set a number");
+                        }
+                    }
+        }
             }
 
             return (SendPort, IP, RecievePort);

--- a/VRCFaceTracking/ArgsHandler.cs
+++ b/VRCFaceTracking/ArgsHandler.cs
@@ -6,10 +6,10 @@ namespace VRCFaceTracking
     public static class ArgsHandler
     {
         
-        public static (int SendPort, string IP, int RecievePort) HandleArgs()
+        public static (int SendPort, string IP, int RecievePort, string opMode) HandleArgs()
         {
             Logger.Msg("Loading Defaults");
-            (int SendPort, string IP, int RecievePort) = (9000, "127.0.0.1", 9001);
+            (int SendPort, string IP, int RecievePort, string opMode) = (9000, "127.0.0.1", 9001, "auto");
 
             foreach (var arg in Environment.GetCommandLineArgs())
             {
@@ -17,6 +17,12 @@ namespace VRCFaceTracking
                 {
                    Logger.Msg("To set custom OSC port/IP config please use the following");
                    Logger.Msg("--osc=<OutPort>:<IP>:<InPort>");
+                   Logger.Msg("To set operating mode please use the following");
+                   Logger.Msg("--mode=vrc or --mode=cvr");
+                }
+                if (arg.StartsWith("--mode"))
+                {
+                  opMode = arg;
                 }
                 if (arg.StartsWith("--osc="))
                 {
@@ -65,7 +71,7 @@ namespace VRCFaceTracking
                 }
             }
 
-            return (SendPort, IP, RecievePort);
+            return (SendPort, IP, RecievePort, opMode);
         }
     }
 }

--- a/VRCFaceTracking/CVR.cs
+++ b/VRCFaceTracking/CVR.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Win32;
+
+namespace VRCFaceTracking
+{
+    public static class CVR
+    {
+        public static readonly string CVRData = Path.Combine(Environment
+            .GetFolderPath(Environment.SpecialFolder.ApplicationData).Replace("Roaming", "LocalLow"), "Alpha Blend Interactive\\ChilloutVR");
+        
+        public static readonly string CVROSCDirectory = Path.Combine(CVRData, "OSC");
+        
+        public static bool IsCVRRunning() => Process.GetProcesses().Any(x => x.ProcessName == "ChilloutVR");
+    }
+}

--- a/VRCFaceTracking/ConfigParser.cs
+++ b/VRCFaceTracking/ConfigParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing.Text;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -9,6 +10,7 @@ namespace VRCFaceTracking
 {
     public static class ConfigParser
     {
+        private static string _oscDir;
         public class InputOutputDef
         {
             public string address { get; set; }
@@ -36,8 +38,22 @@ namespace VRCFaceTracking
 
         public static void ParseNewAvatar(string newId)
         {
+            
+            //check what mode we are in
+            if(Globals.opMode == "vrc")
+            {
+              Logger.Msg("Loading Avatar from VRChat");
+              _oscDir = VRChat.VRCOSCDirectory;
+            }
+            if (Globals.opMode == "cvr")
+            {
+              Logger.Msg("Loading Avatar from ChilloutVR");
+              _oscDir = CVR.CVROSCDirectory;
+            }
+
+            
             AvatarConfigSpec avatarConfig = null;
-            foreach (var userFolder in Directory.GetDirectories(VRChat.VRCOSCDirectory))
+            foreach (var userFolder in Directory.GetDirectories(_oscDir))
             {
                 if (Directory.Exists(userFolder + "\\Avatars"))
                     foreach (var avatarFile in Directory.GetFiles(userFolder+"\\Avatars"))

--- a/VRCFaceTracking/MainStandalone.cs
+++ b/VRCFaceTracking/MainStandalone.cs
@@ -62,7 +62,9 @@ namespace VRCFaceTracking
             Logger.Msg("VRCFT Initializing!");
             
             // Parse Arguments
+
             (_outPort, _ip, _inPort) = ArgsHandler.HandleArgs();
+            Logger.Msg("InPort = " + _inPort + " , OutPort = " + _outPort + " , target IP = " + _ip);
             
             // Load dependencies
             DependencyManager.Load();
@@ -85,10 +87,10 @@ namespace VRCFaceTracking
             OscMain = new OscMain();
             var bindResults = OscMain.Bind(_ip, _outPort, _inPort);
             if (!bindResults.receiverSuccess)
-                Logger.Error("Socket failed to bind to receiver port, please ensure it's not already in use by another program or specify a different one instead.");
+                Logger.Error("Socket failed to bind to receiver port " + _inPort + ", please ensure it's not already in use by another program or specify a different one instead.");
             
             if (!bindResults.senderSuccess)
-                Logger.Error("Socket failed to bind to sender port, please ensure it's not already in use by another program or specify a different one instead.");
+                Logger.Error("Socket failed to bind to sender port "+ _outPort + ", please ensure it's not already in use by another program or specify a different one instead.");
 
             _relevantParams = UnifiedTrackingData.AllParameters.SelectMany(p => p.GetBase()).Where(param => param.Relevant);
 

--- a/VRCFaceTracking/VRCFaceTracking.csproj
+++ b/VRCFaceTracking/VRCFaceTracking.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Params\XYParam.cs" />
     <Compile Include="SDK\ExtTrackingModule.cs" />
     <Compile Include="VRChat.cs" />
+    <Compile Include="CVR.cs" />
     <Compile Include="TrackingLibs\SRanipal\Eye\SRanipal_EyeData.cs" />
     <Compile Include="TrackingLibs\SRanipal\Eye\SRanipal_EyeDataType_v2.cs" />
     <Compile Include="TrackingLibs\SRanipal\Eye\SRanipal_Eye_API.cs" />


### PR DESCRIPTION
The intent of this merge is to:

- Add OSC connection settings reporting (so you can see at a glance what ports/IPs it is using once started)
- Add help message to let you know about the custom OSC options (displayed using common app flags, --options / --help)
- Convert logging in args module so that its output is routed to the Logger interface (where all the other status messages go) 