### PR TITLE
Expose pupil diameter from 0 to 1 cm

### DIFF
--- a/VRCFaceTracking/Params/Eye/EyeTrackingParams.cs
+++ b/VRCFaceTracking/Params/Eye/EyeTrackingParams.cs
@@ -33,6 +33,7 @@ namespace VRCFaceTracking.Params.Eye
             #region Dilation
             
             new EParam(v2 => v2.EyesDilation, "EyesDilation"),
+            new EParam(v2 => v2.EyesPupilDiameter, "EyesPupilDiameter"),
             
             #endregion
             

--- a/VRCFaceTracking/UnifiedTrackingData.cs
+++ b/VRCFaceTracking/UnifiedTrackingData.cs
@@ -44,6 +44,9 @@ namespace VRCFaceTracking
         // SRanipal Exclusive
         public float EyesDilation;
         private float _maxDilation, _minDilation;
+        
+        // Custom parameter
+        public float EyesPupilDiameter;
 
         public void UpdateData(EyeData_v2 eyeData)
         {
@@ -71,7 +74,10 @@ namespace VRCFaceTracking
             Combined.Squeeze = (Left.Squeeze + Right.Squeeze) / 2;
             
             if (dilation != 0)
+            {
                 EyesDilation = (dilation - _minDilation) / (_maxDilation - _minDilation);
+                EyesPupilDiameter = dilation > 10 ? 1 : dilation / 10;
+            }
         }
 
         private void UpdateMinMaxDilation(float readDilation)


### PR DESCRIPTION
- Expose pupil diameter as EyesPupilDiameter to provide tighter control for avatar owners. The existing parameter, EyesDilation, relies on historical eye diameter data acquired since the last avatar change to determine the minimum and maximum eye dilation, which can vary depending on the recent user activity, calibration error, and lighting conditions.
  This makes it difficult to create an eye representation using EyesDilation that best reflect physiological effects that the user may be experiencing during a specific session.
- Due to a lack of available information regarding the iris size on the Vive Pro Eye, the currently exposed diameter is in an absolute unit rather than relative. Exposing other parameters leveraging on other APIs such as the Varjo Aero is out of scope here.
- A pupil diameter of 1 cm is represented with the value of 1.
  According to various sources, human pupil size may contract and expand, reaching diameters between 2mm and 9mm (with no significant digits specified).
  For convenience, the maximum value of 1 represents 1 cm.