### PR TITLE
Start automatically removing 'downloaded from the internet' identifiers from custom modules

### DIFF
--- a/VRCFaceTracking/UnifiedLibManager.cs
+++ b/VRCFaceTracking/UnifiedLibManager.cs
@@ -82,6 +82,8 @@ namespace VRCFaceTracking
             // Load dotnet dlls from the VRCFTLibs folder
             foreach (var dll in Directory.GetFiles(customLibsPath, "*.dll"))
             {
+                RemoveZoneIdentifier(dll);
+
                 Logger.Msg("Loading " + dll);
 
                 Type module;
@@ -212,6 +214,21 @@ namespace VRCFaceTracking
 
             _eyeModule = null;
             _lipModule = null;
+        }
+
+        private static void RemoveZoneIdentifier(string path)
+        {
+            string zoneFile = path + ":Zone.Identifier";
+
+            if (Utils.GetFileAttributes(zoneFile) == 0xffffffff) // INVALID_FILE_ATTRIBUTES
+            {
+                //zone file doesn't exist, everything's good
+                return;
+            }
+            if (Utils.DeleteFile(zoneFile))
+                Logger.Msg("Removing the downloaded file identifier from " + path);
+            else
+                Logger.Error("Couldn't removed the 'file downloaded' mark from " + path + "! The app will probably crash right now so please unblock the file manually");
         }
     }
 }

--- a/VRCFaceTracking/Utils.cs
+++ b/VRCFaceTracking/Utils.cs
@@ -26,6 +26,13 @@ namespace VRCFaceTracking
 
         [DllImport("kernel32.dll")]
         public static extern bool ReadProcessMemory(int hProcess, IntPtr lpBaseAddress, byte[] lpBuffer, int dwSize, ref int lpNumberOfBytesRead);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool DeleteFile(string lpFileName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern uint GetFileAttributes(string lpFileName);
         
         public static readonly bool HasAdmin =
             new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);


### PR DESCRIPTION
That PR is going to fix the main issue of many first time users of custom VRCFT modules that is forgetting to unblock the downloaded module. Yay