### PR TITLE
Fix for VRCFaceTracking crash with port binding

### DIFF
--- a/VRCFaceTracking/OSC/OSCMain.cs
+++ b/VRCFaceTracking/OSC/OSCMain.cs
@@ -39,8 +39,11 @@ namespace VRCFaceTracking.OSC
             {
                 SenderClient.Connect(new IPEndPoint(IPAddress.Parse(address), outPort));
                 senderSuccess = true;
+                
+                ReceiverClient.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                 ReceiverClient.Bind(new IPEndPoint(IPAddress.Parse(address), inPort));
                 receiverSuccess = true;
+                
                 ReceiverClient.ReceiveTimeout = 1000;
                 
                 _receiveThread = new Thread(() =>
@@ -48,6 +51,7 @@ namespace VRCFaceTracking.OSC
                     while (!MainStandalone.MasterCancellationTokenSource.IsCancellationRequested)
                         Recv();
                 });
+                
                 _receiveThread.Start();
             }
             catch (Exception)


### PR DESCRIPTION
Right now VRCFaceTracking fails to bind the input port if it's already bound to another app, preventing it from working. Setting it to reuse the address will allow VRCFaceTracking to boot even when another app already bound itself to the port.