### PR TITLE
Add command line arguments to disable eye/lip tracking

### DIFF
--- a/VRCFaceTracking/ArgsHandler.cs
+++ b/VRCFaceTracking/ArgsHandler.cs
@@ -5,9 +5,10 @@ namespace VRCFaceTracking
 {
     public static class ArgsHandler
     {
-        public static (int SendPort, string IP, int RecievePort) HandleArgs()
+        public static (int SendPort, string IP, int RecievePort, bool EnableEye, bool EnableLip) HandleArgs()
         {
             (int SendPort, string IP, int RecievePort) = (9000, "127.0.0.1", 9001);
+            (bool EnableEye, bool EnableLip) = (true, true);
             
             foreach (var arg in Environment.GetCommandLineArgs())
             {
@@ -39,9 +40,17 @@ namespace VRCFaceTracking
                         break;
                     }
                 }
+                else if (arg.ToLower().Equals("--disable-eye"))
+                {
+                    EnableEye = false;
+                }
+                else if (arg.ToLower().Equals("--disable-lip"))
+                {
+                    EnableLip = false;
+                }
             }
 
-            return (SendPort, IP, RecievePort);
+            return (SendPort, IP, RecievePort, EnableEye, EnableLip);
         }
     }
 }

--- a/VRCFaceTracking/MainStandalone.cs
+++ b/VRCFaceTracking/MainStandalone.cs
@@ -42,6 +42,8 @@ namespace VRCFaceTracking
         private static string _ip = "127.0.0.1";
         private static int _inPort = 9001, _outPort = 9000;
 
+        private static bool _enableEye = true, _enableLip = true;
+
         public static readonly CancellationTokenSource MasterCancellationTokenSource = new CancellationTokenSource();
 
         public static void Teardown()
@@ -62,7 +64,7 @@ namespace VRCFaceTracking
             Logger.Msg("VRCFT Initializing!");
             
             // Parse Arguments
-            (_outPort, _ip, _inPort) = ArgsHandler.HandleArgs();
+            (_outPort, _ip, _inPort, _enableEye, _enableLip) = ArgsHandler.HandleArgs();
             
             // Load dependencies
             DependencyManager.Load();
@@ -79,7 +81,7 @@ namespace VRCFaceTracking
             }
             
             // Initialize Tracking Runtimes
-            UnifiedLibManager.Initialize();
+            UnifiedLibManager.Initialize(_enableEye, _enableLip);
 
             // Initialize Locals
             OscMain = new OscMain();

--- a/VRCFaceTracking/MainStandalone.cs
+++ b/VRCFaceTracking/MainStandalone.cs
@@ -39,11 +39,6 @@ namespace VRCFaceTracking
         private static IEnumerable<OSCParams.BaseParam> _relevantParams;
         private static int _relevantParamsCount = 416;
 
-        private static string _ip = "127.0.0.1";
-        private static int _inPort = 9001, _outPort = 9000;
-
-        private static bool _enableEye = true, _enableLip = true;
-
         public static readonly CancellationTokenSource MasterCancellationTokenSource = new CancellationTokenSource();
 
         public static void Teardown()
@@ -64,7 +59,7 @@ namespace VRCFaceTracking
             Logger.Msg("VRCFT Initializing!");
             
             // Parse Arguments
-            (_outPort, _ip, _inPort, _enableEye, _enableLip) = ArgsHandler.HandleArgs();
+            (int outPort, string ip, int inPort, bool enableEye, bool enableLip) = ArgsHandler.HandleArgs();
             
             // Load dependencies
             DependencyManager.Load();
@@ -81,11 +76,11 @@ namespace VRCFaceTracking
             }
             
             // Initialize Tracking Runtimes
-            UnifiedLibManager.Initialize(_enableEye, _enableLip);
+            UnifiedLibManager.Initialize(enableEye, enableLip);
 
             // Initialize Locals
             OscMain = new OscMain();
-            var bindResults = OscMain.Bind(_ip, _outPort, _inPort);
+            var bindResults = OscMain.Bind(ip, outPort, inPort);
             if (!bindResults.receiverSuccess)
                 Logger.Error("Socket failed to bind to receiver port, please ensure it's not already in use by another program or specify a different one instead.");
             

--- a/VRCFaceTracking/UnifiedLibManager.cs
+++ b/VRCFaceTracking/UnifiedLibManager.cs
@@ -55,6 +55,12 @@ namespace VRCFaceTracking
         public static void Initialize(bool eye = true, bool lip = true)
         {
             if (_initializeWorker != null && _initializeWorker.IsAlive) _initializeWorker.Abort();
+
+            if (!eye)
+                Logger.Warning("Eye Tracking disabled by --disable-eye for this session.");
+
+            if (!lip)
+                Logger.Warning("Lip Tracking disabled by --disable-lip for this session.");
             
             // Start Initialization
             _initializeWorker = new Thread(() =>

--- a/VRCFaceTracking/UnifiedLibManager.cs
+++ b/VRCFaceTracking/UnifiedLibManager.cs
@@ -56,12 +56,6 @@ namespace VRCFaceTracking
         {
             if (_initializeWorker != null && _initializeWorker.IsAlive) _initializeWorker.Abort();
 
-            if (!eye)
-                Logger.Warning("Eye Tracking disabled by --disable-eye for this session.");
-
-            if (!lip)
-                Logger.Warning("Lip Tracking disabled by --disable-lip for this session.");
-            
             // Start Initialization
             _initializeWorker = new Thread(() =>
             {
@@ -71,7 +65,8 @@ namespace VRCFaceTracking
                 // Init
                 FindAndInitRuntimes(eye, lip);
             });
-            Logger.Msg("Starting initialization thread");
+            
+            Logger.Msg("Starting initialization for " + (eye ? "eye" : "") + (eye && lip ? " and " : "") + (lip ? "lip" : "") + " tracking");
             _initializeWorker.Start();
         }
 


### PR DESCRIPTION
Adds --disable-eye and --disable-lip which are passed to the tracking module to disable loading of each respectively if not needed.

For reference this is because I've had an eye surgery and I would like to be able to use the lip tracker without my eye tracker firing up and shooting IR into my recovering eye, but I figured generalizing this might be useful to others.