### PR TITLE
Add ExpressionTrackingActive

### DIFF
--- a/VRCFaceTracking.Core/Params/Expressions/UnifiedExpressionsMerger.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/UnifiedExpressionsMerger.cs
@@ -281,6 +281,7 @@ public static class UnifiedExpressionsMerger
         #endregion
 
         new ConditionalBoolParameter(exp => (UnifiedLibManager.EyeStatus == ModuleState.Active, UnifiedLibManager.EyeStatus != ModuleState.Uninitialized), "EyeTrackingActive"),
+        new ConditionalBoolParameter(exp => (UnifiedLibManager.ExpressionStatus == ModuleState.Active, UnifiedLibManager.ExpressionStatus != ModuleState.Uninitialized), "ExpressionTrackingActive"),
         new ConditionalBoolParameter(exp => (UnifiedLibManager.ExpressionStatus == ModuleState.Active, UnifiedLibManager.ExpressionStatus != ModuleState.Uninitialized), "LipTrackingActive")
 
     };


### PR DESCRIPTION
As part of the larger Lip -> Expression update

Seem to have been missed in the overall update, I know the special case handling the parameter changing in game making it back to VRCFT is commented out for now but that was the only place I could find it actually in the code, so this should be what's needed to have it actually function.

Of note also ExpressionTrackingActive would then also need to be on [the wiki docs](https://github.com/benaclejames/VRCFaceTracking/wiki/Parameters).