### PR TITLE
[v5.0.0] Module Registry naming fixes, Addition of a proper `nuget.config`, and VSCode `.gitignore` inclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# VSCode Files
+.vscode/
+
 # Visual Studio files
 .vs/
 bin/

--- a/VRCFaceTracking/Strings/en/Resources.resw
+++ b/VRCFaceTracking/Strings/en/Resources.resw
@@ -222,7 +222,7 @@
     <value>File a bug or request new sample</value>
   </data>
   <data name="LastUpdated.Text" xml:space="preserve">
-    <value>LastUpdated</value>
+    <value>Last Updated</value>
   </data>
   <data name="LegacyParameters.Text" xml:space="preserve">
     <value>Legacy Parameters</value>
@@ -231,7 +231,7 @@
     <value>Listening on Port:</value>
   </data>
   <data name="ModulePage.Text" xml:space="preserve">
-    <value>ModulePage</value>
+    <value>Module Page</value>
   </data>
   <data name="msIncoming.Text" xml:space="preserve">
     <value>m/s Incoming</value>
@@ -264,7 +264,7 @@
     <value>To clone this repository</value>
   </data>
   <data name="UsageInstructions.Text" xml:space="preserve">
-    <value>UsageInstructions</value>
+    <value>Usage Instructions</value>
   </data>
   <data name="Version.Text" xml:space="preserve">
     <value>Version</value>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="CommunityToolkit-Labs" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
- Added spaces to the English translation file for the module registry page where applicable.
- Added the external package repository "CommunityToolkit-Labs" to nuget.config to ease in setting up a proper build environment.
- Added VSCode to the .gitignore.