### PR TITLE
use system environment variable for Appdata and Appdata/LocalLow

### DIFF
--- a/VRCFaceTracking.Core/Utils.cs
+++ b/VRCFaceTracking.Core/Utils.cs
@@ -33,7 +33,7 @@ namespace VRCFaceTracking
         
         public static readonly bool HasAdmin = new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
         
-        public static readonly string PersistentDataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VRCFaceTracking");
+        public static readonly string PersistentDataDirectory = Path.Combine(Environment.GetEnvironmentVariable("appdata"), "VRCFaceTracking");
         public static readonly string CustomLibsDirectory = PersistentDataDirectory + "\\CustomLibs";
     }
 }

--- a/VRCFaceTracking.Core/VRChat.cs
+++ b/VRCFaceTracking.Core/VRChat.cs
@@ -5,8 +5,7 @@ namespace VRCFaceTracking.Core
 {
     public static class VRChat
     {
-        public static readonly string VRCData = Path.Combine(Environment
-            .GetFolderPath(Environment.SpecialFolder.ApplicationData).Replace("Roaming", "LocalLow"), "VRChat\\VRChat");
+        public static readonly string VRCData = Path.Combine($"{Environment.GetEnvironmentVariable("localappdata")}Low", "VRChat\\VRChat");
         
         public static readonly string VRCOSCDirectory = Path.Combine(VRCData, "OSC");
         


### PR DESCRIPTION
Should address the issues with Appdata using the folder in Packages in addition to the Appdata/Roaming folder.
Appdata/LocalLow change prevents extremely rare crash when user for some reason has their Roaming folder and Local/LocalLow folders in separate drives..