### PR TITLE
Fix use of vcruntime140.dll

### DIFF
--- a/VRCFaceTracking.Core/VRCFaceTracking.Core.csproj
+++ b/VRCFaceTracking.Core/VRCFaceTracking.Core.csproj
@@ -13,7 +13,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\..\..\..\..\Windows\System32\vcruntime140.dll" Link="vcruntime140.dll">
+    <Content Include="C:\Windows\System32\vcruntime140.dll" Link="vcruntime140.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
Use absolute path instead of local path for fetching `vcruntime140.dll`.