### PR TITLE
Parameter name consistency fix

### DIFF
--- a/VRCFaceTracking.Core/Params/Expressions/UnifiedExpressionsParameters.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/UnifiedExpressionsParameters.cs
@@ -235,12 +235,12 @@ public static class UnifiedExpressionsParameters
 
         // Compacted paramamters
 
-        new EParam("v2/MouthTightenStretch", exp =>
+        new EParam("v2/MouthTightenerStretch", exp =>
             (exp.Shapes[(int)UnifiedExpressions.MouthTightenerRight].Weight + exp.Shapes[(int)UnifiedExpressions.MouthTightenerLeft].Weight) / 2.0f -
             (exp.Shapes[(int)UnifiedExpressions.MouthStretchRight].Weight + exp.Shapes[(int)UnifiedExpressions.MouthStretchLeft].Weight) / 2.0f),
 
-        new EParam("v2/MouthTightenStretchLeft", exp => exp.Shapes[(int)UnifiedExpressions.MouthTightenerLeft].Weight - exp.Shapes[(int)UnifiedExpressions.MouthStretchLeft].Weight),
-        new EParam("v2/MouthTightenStretchRight", exp => exp.Shapes[(int)UnifiedExpressions.MouthTightenerRight].Weight - exp.Shapes[(int)UnifiedExpressions.MouthStretchRight].Weight),
+        new EParam("v2/MouthTightenerStretchLeft", exp => exp.Shapes[(int)UnifiedExpressions.MouthTightenerLeft].Weight - exp.Shapes[(int)UnifiedExpressions.MouthStretchLeft].Weight),
+        new EParam("v2/MouthTightenerStretchRight", exp => exp.Shapes[(int)UnifiedExpressions.MouthTightenerRight].Weight - exp.Shapes[(int)UnifiedExpressions.MouthStretchRight].Weight),
         #endregion
 
         #region Lip Corners Combined


### PR DESCRIPTION
Changed 
v2/MouthTightenStretch/Left/Right to
v2/MouthTightenerStretch/Left/Right for consistency with existing v2/MouthTightener parameter

Nice catch jerry