### PR TITLE
Settings improvements

### DIFF
--- a/VRCFaceTracking/Views/SettingsPage.xaml
+++ b/VRCFaceTracking/Views/SettingsPage.xaml
@@ -145,7 +145,7 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Image Grid.Column="0" Source="{x:Bind UpperImageSource}" Stretch="Uniform" />
-                        <AppBarSeparator Grid.Column="1" />
+                        <AppBarSeparator x:Name="HardwareDebugSeparator" Grid.Column="1" />
                         <Image Grid.Column="2" Source="{x:Bind LowerImageSource}" Stretch="Uniform" />
                     </Grid>
                 </labs:SettingsCard>

--- a/VRCFaceTracking/Views/SettingsPage.xaml.cs
+++ b/VRCFaceTracking/Views/SettingsPage.xaml.cs
@@ -139,6 +139,15 @@ public sealed partial class SettingsPage : Page
                 _lowerStream = null;
             }
         }
+
+        if ( _lowerStream == null || _upperStream == null )
+        {
+            HardwareDebugSeparator.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            HardwareDebugSeparator.Visibility = Visibility.Visible;
+        }
     }
 
     private void OnPageLoaded(object sender, RoutedEventArgs e)

--- a/VRCFaceTracking/Views/SettingsPage.xaml.cs
+++ b/VRCFaceTracking/Views/SettingsPage.xaml.cs
@@ -61,7 +61,7 @@ public sealed partial class SettingsPage : Page
 
         Loaded += OnPageLoaded;
         
-        UnifiedTracking.OnUnifiedDataUpdated += _ => DispatcherQueue.TryEnqueue(OnTrackingDataUpdated);
+        UnifiedTracking.OnUnifiedDataUpdated += _ => DispatcherQueue?.TryEnqueue(OnTrackingDataUpdated);
         InitializeComponent();
     }
 


### PR DESCRIPTION
This PR does two changes:
1. Fixes a crash that could occur when shutting down VRCFT on the settings page.
2. Fixes the Hardware Debug Streams panel using more spacing than necessary when using HMDs with either zero or one debug stream (eg using a Quest Pro, or only a Vive Facial Tracker)