### PR TITLE
Add sandboxing to modules

### DIFF
--- a/VRCFaceTracking.Core/Models/SubprocessData.cs
+++ b/VRCFaceTracking.Core/Models/SubprocessData.cs
@@ -1,0 +1,30 @@
+﻿using System.Runtime.InteropServices;
+using VRCFaceTracking.Core.Params;
+using VRCFaceTracking.Core.Params.Data;
+using VRCFaceTracking.Core.Params.Expressions;
+using VRCFaceTracking.Core.Params.Expressions.Legacy.Eye;
+using VRCFaceTracking.Core.Params.Expressions.Legacy.Lip;
+using VRCFaceTracking.Core.Types;
+
+namespace VRCFaceTracking.Core.Models;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct SubprocessData
+{
+    public ModuleMetadata ModuleData;
+
+    // Mirror of params modules manipulate in UnifiedTracking
+    public Image EyeImageData = new Image();
+    public Image LipImageData = new Image();
+    public UnifiedTrackingData Data = new();
+#pragma warning disable CS0618
+    public readonly Parameter[] AllParameters_v1 = LipShapeMerger.AllLipParameters.Union(EyeTrackingParams.ParameterList).ToArray();
+    public readonly Parameter[] AllParameters_v2 = UnifiedExpressionsParameters.ExpressionParameters;
+#pragma warning restore CS0618
+
+    public SubprocessData()
+    {
+
+    }
+
+}

--- a/VRCFaceTracking.Core/Sandboxing/VrcftSandboxServer.cs
+++ b/VRCFaceTracking.Core/Sandboxing/VrcftSandboxServer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VRCFaceTracking.Core.Models;
+
+namespace VRCFaceTracking.Core.Sandboxing;
+public class VrcftSandboxServer
+{
+    private static readonly Random Random = new ();
+
+    private string _namedPipeString;
+
+    // View into the sub-process' local data
+    private SubprocessData _subprocessData = new();
+
+    public VrcftSandboxServer(string targetNamedPipe)
+    {
+        _namedPipeString = $"{targetNamedPipe}_moduleId{Random.NextInt64()}";
+    }
+}

--- a/VRCFaceTracking.ModuleProcess/ModuleProcessExitCodes.cs
+++ b/VRCFaceTracking.ModuleProcess/ModuleProcessExitCodes.cs
@@ -1,0 +1,7 @@
+﻿namespace VRCFaceTracking.ModuleProcess;
+public static class ModuleProcessExitCodes
+{
+    public const int OK                                         =  0;
+    public const int INVALID_ARGS                               = -1;
+    public const int NAMED_PIPE_CONNECTION_TIMED_OUT            = -2;
+}

--- a/VRCFaceTracking.ModuleProcess/ModuleProcessMain.cs
+++ b/VRCFaceTracking.ModuleProcess/ModuleProcessMain.cs
@@ -1,0 +1,9 @@
+﻿namespace VRCFaceTracking.ModuleProcess;
+
+public class ModuleProcessMain
+{
+    public static int Main(string[] args)
+    {
+        return ModuleProcessExitCodes.OK;
+    }
+}

--- a/VRCFaceTracking.ModuleProcess/ModuleProcessMain.cs
+++ b/VRCFaceTracking.ModuleProcess/ModuleProcessMain.cs
@@ -4,6 +4,15 @@ public class ModuleProcessMain
 {
     public static int Main(string[] args)
     {
+        if (args.Length < 1)
+        {
+            return ModuleProcessExitCodes.INVALID_ARGS;
+        }
+
+        string namedPipeDestination = string.Join(' ', args);
+
+        // A module process will connect to a given named pipe first. We try connecting to the named pipe for 30 seconds, then give up, returning an error code in the process.
+
         return ModuleProcessExitCodes.OK;
     }
 }

--- a/VRCFaceTracking.ModuleProcess/VRCFaceTracking.ModuleProcess.csproj
+++ b/VRCFaceTracking.ModuleProcess/VRCFaceTracking.ModuleProcess.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <SelfContained>true</SelfContained>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Platforms>x86;x64;ARM64</Platforms>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RootNamespace>VRCFaceTracking.ModuleProcess</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VRCFaceTracking.Core\VRCFaceTracking.Core.csproj" />
+    <ProjectReference Include="..\VRCFaceTracking.SDK\VRCFaceTracking.SDK.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/VRCFaceTracking.ModuleProcess/VrcftSandboxClient.cs
+++ b/VRCFaceTracking.ModuleProcess/VrcftSandboxClient.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VRCFaceTracking.ModuleProcess;
+public class VrcftSandboxClient
+{
+    public VrcftSandboxClient(string targetNamedPipe)
+    {
+    
+    }
+}

--- a/VRCFaceTracking.ModuleProcess/app.manifest
+++ b/VRCFaceTracking.ModuleProcess/app.manifest
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="VRCFaceTracking.moduleSubProcess"/>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/VRCFaceTracking.sln
+++ b/VRCFaceTracking.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VRCFaceTracking.Core", "VRC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VRCFaceTracking.SDK", "VRCFaceTracking.SDK\VRCFaceTracking.SDK.csproj", "{8B86A697-6458-4279-94FB-DD6BFEF5547E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VRCFaceTracking.ModuleProcess", "VRCFaceTracking.ModuleProcess\VRCFaceTracking.ModuleProcess.csproj", "{43837392-E314-488D-853F-1557F68B3005}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,7 +50,6 @@ Global
 		{7E29B109-E682-4F89-A47D-5A3CC5CD5F41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7E29B109-E682-4F89-A47D-5A3CC5CD5F41}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E29B109-E682-4F89-A47D-5A3CC5CD5F41}.Debug|arm64.ActiveCfg = Debug|arm64
-        {7E29B109-E682-4F89-A47D-5A3CC5CD5F41}.Debug|arm64.Build.0 = Debug|arm64
 		{7E29B109-E682-4F89-A47D-5A3CC5CD5F41}.Debug|x64.ActiveCfg = Debug|x64
 		{7E29B109-E682-4F89-A47D-5A3CC5CD5F41}.Debug|x64.Build.0 = Debug|x64
 		{7E29B109-E682-4F89-A47D-5A3CC5CD5F41}.Debug|x86.ActiveCfg = Debug|x86
@@ -63,16 +64,36 @@ Global
 		{7E29B109-E682-4F89-A47D-5A3CC5CD5F41}.Release|x86.Build.0 = Release|x86
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Debug|arm64.Build.0 = Debug|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Debug|x64.Build.0 = Debug|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Debug|x86.Build.0 = Debug|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Release|arm64.ActiveCfg = Release|Any CPU
+		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Release|arm64.Build.0 = Release|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Release|x64.ActiveCfg = Release|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Release|x64.Build.0 = Release|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Release|x86.ActiveCfg = Release|Any CPU
 		{8B86A697-6458-4279-94FB-DD6BFEF5547E}.Release|x86.Build.0 = Release|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Debug|arm64.Build.0 = Debug|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Debug|x64.Build.0 = Debug|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Debug|x86.Build.0 = Debug|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Release|arm64.ActiveCfg = Release|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Release|arm64.Build.0 = Release|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Release|x64.ActiveCfg = Release|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Release|x64.Build.0 = Release|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Release|x86.ActiveCfg = Release|Any CPU
+		{43837392-E314-488D-853F-1557F68B3005}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VRCFaceTracking/VRCFaceTracking.csproj
+++ b/VRCFaceTracking/VRCFaceTracking.csproj
@@ -9,9 +9,9 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
-	<ImplicitUsings>enable</ImplicitUsings>
-	<Nullable>enable</Nullable>
-	<UseWinUI>true</UseWinUI>
+	  <ImplicitUsings>enable</ImplicitUsings>
+	  <Nullable>enable</Nullable>
+	  <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <GenerateAppInstallerFile>True</GenerateAppInstallerFile>

--- a/VRCFaceTracking/VRCFaceTracking.csproj
+++ b/VRCFaceTracking/VRCFaceTracking.csproj
@@ -67,6 +67,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\VRCFaceTracking.Core\VRCFaceTracking.Core.csproj" />
+    <ProjectReference Include="..\VRCFaceTracking.ModuleProcess\VRCFaceTracking.ModuleProcess.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="Assets\WindowIcon.ico">

--- a/VRCFaceTracking/Views/SettingsPage.xaml
+++ b/VRCFaceTracking/Views/SettingsPage.xaml
@@ -145,7 +145,7 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Image Grid.Column="0" Source="{x:Bind UpperImageSource}" Stretch="Uniform" />
-                        <AppBarSeparator Grid.Column="1" />
+                        <AppBarSeparator x:Name="HardwareDebugSeparator" Grid.Column="1" />
                         <Image Grid.Column="2" Source="{x:Bind LowerImageSource}" Stretch="Uniform" />
                     </Grid>
                 </labs:SettingsCard>

--- a/VRCFaceTracking/Views/SettingsPage.xaml.cs
+++ b/VRCFaceTracking/Views/SettingsPage.xaml.cs
@@ -139,6 +139,15 @@ public sealed partial class SettingsPage : Page
                 _lowerStream = null;
             }
         }
+
+        if ( _lowerStream == null || _upperStream == null )
+        {
+            HardwareDebugSeparator.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            HardwareDebugSeparator.Visibility = Visibility.Visible;
+        }
     }
 
     private void OnPageLoaded(object sender, RoutedEventArgs e)

--- a/VRCFaceTracking/Views/SettingsPage.xaml.cs
+++ b/VRCFaceTracking/Views/SettingsPage.xaml.cs
@@ -61,7 +61,7 @@ public sealed partial class SettingsPage : Page
 
         Loaded += OnPageLoaded;
         
-        UnifiedTracking.OnUnifiedDataUpdated += _ => DispatcherQueue.TryEnqueue(OnTrackingDataUpdated);
+        UnifiedTracking.OnUnifiedDataUpdated += _ => DispatcherQueue?.TryEnqueue(OnTrackingDataUpdated);
         InitializeComponent();
     }
 


### PR DESCRIPTION
This PR will be a major overhaul of how the module system works internally. This does **NOT** aim to change the API modules interact with in any way - it only aims to be a major improvement in stability and flexibility from the point of view of module developers and end users.

This change will attempt to improve VRCFT's stability and introduce a whole range of flexibility into the program.

Sandboxing shall be implemented in a similar fashion to browser tabs. Each module will be a sub-process, which will communicate to the main VRCFT process using named pipes. Each sub-process will then maintain it's own instance of the `UnifiedExpressions` class, and share it with the main process over the aforementioned named pipe. This will allow for low-latency IPC between each sub-process and the main process. Solving race conditions will be tricky in a manner which minimises latency, but is a doable task. The main process will then combine the incoming data from each sub-process together into what shall ultimately be sent to applications such as VRChat.

If a sub-process is left running after VRCFT is closed, the sub-process will terminate itself, to eliminate ghost processes. This will either be done using a heartbeat between the main process and each module sub-process, or by having the module sub-processes periodically check for the presence of VRCFT itself in the background, or, likely a combination of both for extra redundancy.

Sandboxing will allow:
1. Modules which misbehave to not hang VRCFT. For instance, say someone is using a module similar to the Sranipal module, which primarily interacts using a native C++ DLL to the eye and face tracking runtime, and Sranipal crashes for whatever reason. Due to poor programming in the C++ DLL, the DLL would hang VRCFT and force the user to restart VRCFT through task manager. This is not ideal as it is a poor user experience. Sandboxing will allow VRCFT to terminate modules which misbehave such as in the aforementioned example.
2. Users will now be able to restart, install and uninstall modules without having to restart VRCFT. Since modules will now be sub-processes, restarting, installing and uninstalling will be as simple as launching a sub-process.
3. Users will also be able to disable and enable parts of the module, so that users can more easily mix different modules with one another. For instance, if one has a Quest Pro and is using a Vive Facial tracker with it, instead of having to fork the Quest Pro module they are using to disable face tracking, they can simply disable it in VRCFT itself.
4. Developers will be able to develop modules more easily. Since VRCFT will be able to reload modules live, it will enable hot reloading, which shall reduce iteration time for module developers.

This PR is currently a work in progress, but I'm opening a draft pull request so that should any changes be wanted, we may discuss them before I put in the effort in realising them.