### PR TITLE
Prevent newer (unreleased) Local Modules being overwritten by Registry.

### DIFF
--- a/VRCFaceTracking/Services/ActivationService.cs
+++ b/VRCFaceTracking/Services/ActivationService.cs
@@ -119,20 +119,14 @@ public class ActivationService : IActivationService
         var outdatedModules = remoteModules.Where(rm => localModules.Any(lm =>
         {
             if (rm.ModuleId != lm.ModuleId) 
-            {
                 return false;
-            }
 
-            var remoteVersSplit = rm.Version.Split(".");
-            var localVersSplit = lm.Version.Split(".");
+            var remoteVersion = new Version(rm.Version);
+            var localVersion = new Version(lm.Version);
 
-            for (int i = 0; i < localVersSplit.Length; i++)
-            {
-                if (i > remoteVersSplit.Length) 
-                    return false;
-                if (int.Parse(localVersSplit[i]) < int.Parse(remoteVersSplit[i]))
-                    return true;
-            }
+            var result = remoteVersion.CompareTo(localVersion);
+            if (result > 0) // remote module version is higher than registry
+                return true;
 
             return false;
         }));

--- a/VRCFaceTracking/Services/ActivationService.cs
+++ b/VRCFaceTracking/Services/ActivationService.cs
@@ -124,11 +124,7 @@ public class ActivationService : IActivationService
             var remoteVersion = new Version(rm.Version);
             var localVersion = new Version(lm.Version);
 
-            var result = remoteVersion.CompareTo(localVersion);
-            if (result > 0) // remote module version is higher than registry
-                return true;
-
-            return false;
+            return remoteVersion.CompareTo(localVersion) > 0;
         }));
         foreach (var outdatedModule in outdatedModules)
         {


### PR DESCRIPTION
Simple as the title suggests. Changes registry activation behavior to prevent local modules being overwritten in the case that they have a higher version number, as opposed to a different version regardless of higher versioning or not.