### PR TITLE
Fixed crash on invalid ip and or port change

### DIFF
--- a/VRCFaceTracking.Core/Models/OscTarget.cs
+++ b/VRCFaceTracking.Core/Models/OscTarget.cs
@@ -1,11 +1,11 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using VRCFaceTracking.Core.Contracts;
 using VRCFaceTracking.Core.Contracts.Services;
-using System.Net;
+using VRCFaceTracking.Core.Validation;
 
 namespace VRCFaceTracking.Core.Models;
 
-public partial class OscTarget : ObservableObject, IOscTarget
+public partial class OscTarget : ObservableValidator, IOscTarget
 {
     [ObservableProperty] private bool _isConnected;
 
@@ -21,39 +21,11 @@ public partial class OscTarget : ObservableObject, IOscTarget
     [NotifyPropertyChangedFor(nameof(InPort))] [NotifyPropertyChangedFor(nameof(OutPort))]
 
     [property: SavedSetting("OSCAddress", "127.0.0.1")]
+    [ValidIpAddress]
     private string _destinationAddress;
-
-    private const string DefaultAddress = "127.0.0.1";
-    private bool _isReverting = false;
 
     public OscTarget(ILocalSettingsService localSettingsService)
     {
         PropertyChanged += (_, _) => localSettingsService.Save(this);
     }
-
-    /// Called after the DestinationAddress property has changed.
-    /// It validates the new address and reverts it to the default if invalid.
-    partial void OnDestinationAddressChanged(string oldValue, string newValue)
-    {
-        // Prevent re-entrancy if we're already reverting
-        if (_isReverting)
-        {
-            return;
-        }
-
-        _isReverting = true;
-
-        // Check if the new address is valid and revert if invalid
-        if (!IsValidAddress(newValue))
-        {
-            DestinationAddress = DefaultAddress;
-        }
-
-        _isReverting = false;
-    }
-
-    /// Validates whether the provided address is a valid IP address or resolvable hostname.
-    private static bool IsValidAddress(string address) =>
-        !string.IsNullOrWhiteSpace(address) &&
-        IPAddress.TryParse(address, out _);
 }

--- a/VRCFaceTracking.Core/Models/OscTarget.cs
+++ b/VRCFaceTracking.Core/Models/OscTarget.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using VRCFaceTracking.Core.Contracts;
 using VRCFaceTracking.Core.Contracts.Services;
+using System.Net;
 
 namespace VRCFaceTracking.Core.Models;
 
@@ -8,19 +9,95 @@ public partial class OscTarget : ObservableObject, IOscTarget
 {
     [ObservableProperty] private bool _isConnected;
 
-    [ObservableProperty] [property: SavedSetting("OSCInPort", 9001)]
+    [ObservableProperty]
+    [property: SavedSetting("OSCInPort", 9001)]
     private int _inPort;
 
-    [ObservableProperty] [property: SavedSetting("OSCOutPort", 9000)]
+    [ObservableProperty]
+    [property: SavedSetting("OSCOutPort", 9000)]
     private int _outPort;
 
-    [ObservableProperty] 
-    [NotifyPropertyChangedFor(nameof(InPort))] [NotifyPropertyChangedFor(nameof(OutPort))]
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(InPort))]
+    [NotifyPropertyChangedFor(nameof(OutPort))]
     [property: SavedSetting("OSCAddress", "127.0.0.1")]
     private string _destinationAddress;
-    
+
+    private const string DefaultAddress = "127.0.0.1";
+    private const int DefaultInPort = 9001;
+    private const int DefaultOutPort = 9000;
+    private bool _isReverting = false;
+
     public OscTarget(ILocalSettingsService localSettingsService)
     {
         PropertyChanged += (_, _) => localSettingsService.Save(this);
+    }
+
+    /// Called after the DestinationAddress property has changed.
+    /// It validates the new address and reverts it to the default if invalid.
+    partial void OnDestinationAddressChanged(string oldValue, string newValue)
+    {
+        // Prevent re-entrancy if we're already reverting
+        if (_isReverting)
+        {
+            return;
+        }
+
+        _isReverting = true;
+
+        // Check if the new address is valid and revert if invalid
+        if (!IsValidAddress(newValue))
+        {
+            DestinationAddress = DefaultAddress;
+        }
+
+        _isReverting = false;
+    }
+
+    /// Called after the InPort property has changed.
+    /// It checks if the InPort is valid and reverts to the default if it's invalid (less than 1).
+    partial void OnInPortChanged(int oldValue, int newValue)
+    {
+        if (newValue < 1)
+        {
+            InPort = DefaultInPort;
+        }
+    }
+
+    /// Called after the OutPort property has changed.
+    /// It checks if the OutPort is valid and reverts to the default if it's invalid (less than 1).
+    partial void OnOutPortChanged(int oldValue, int newValue)
+    {
+        if (newValue < 1)
+        {
+            OutPort = DefaultOutPort;
+        }
+    }
+
+    /// Validates whether the provided address is a valid IP address or resolvable hostname.
+    private static bool IsValidAddress(string address)
+    {
+        if (string.IsNullOrWhiteSpace(address))
+        {
+            return false;
+        }
+
+        // Check if it's a valid IP address
+        if (IPAddress.TryParse(address, out _))
+        {
+            return true;
+        }
+
+        // Check if it's a resolvable hostname
+        try
+        {
+            var hostEntry = Dns.GetHostEntry(address);
+            return true;
+        }
+        catch
+        {
+            // DNS resolution failed
+            return false;
+        }
     }
 }

--- a/VRCFaceTracking.Core/Models/OscTarget.cs
+++ b/VRCFaceTracking.Core/Models/OscTarget.cs
@@ -9,17 +9,17 @@ public partial class OscTarget : ObservableObject, IOscTarget
 {
     [ObservableProperty] private bool _isConnected;
 
-    [ObservableProperty]
-    [property: SavedSetting("OSCInPort", 9001)]
+    [ObservableProperty] [property: SavedSetting("OSCInPort", 9001)]
+
     private int _inPort;
 
-    [ObservableProperty]
-    [property: SavedSetting("OSCOutPort", 9000)]
+    [ObservableProperty] [property: SavedSetting("OSCOutPort", 9000)]
+
     private int _outPort;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(InPort))]
-    [NotifyPropertyChangedFor(nameof(OutPort))]
+    [NotifyPropertyChangedFor(nameof(InPort))] [NotifyPropertyChangedFor(nameof(OutPort))]
+
     [property: SavedSetting("OSCAddress", "127.0.0.1")]
     private string _destinationAddress;
 

--- a/VRCFaceTracking.Core/Models/OscTarget.cs
+++ b/VRCFaceTracking.Core/Models/OscTarget.cs
@@ -24,8 +24,6 @@ public partial class OscTarget : ObservableObject, IOscTarget
     private string _destinationAddress;
 
     private const string DefaultAddress = "127.0.0.1";
-    private const int DefaultInPort = 9001;
-    private const int DefaultOutPort = 9000;
     private bool _isReverting = false;
 
     public OscTarget(ILocalSettingsService localSettingsService)
@@ -54,50 +52,8 @@ public partial class OscTarget : ObservableObject, IOscTarget
         _isReverting = false;
     }
 
-    /// Called after the InPort property has changed.
-    /// It checks if the InPort is valid and reverts to the default if it's invalid (less than 1).
-    partial void OnInPortChanged(int oldValue, int newValue)
-    {
-        if (newValue < 1)
-        {
-            InPort = DefaultInPort;
-        }
-    }
-
-    /// Called after the OutPort property has changed.
-    /// It checks if the OutPort is valid and reverts to the default if it's invalid (less than 1).
-    partial void OnOutPortChanged(int oldValue, int newValue)
-    {
-        if (newValue < 1)
-        {
-            OutPort = DefaultOutPort;
-        }
-    }
-
     /// Validates whether the provided address is a valid IP address or resolvable hostname.
-    private static bool IsValidAddress(string address)
-    {
-        if (string.IsNullOrWhiteSpace(address))
-        {
-            return false;
-        }
-
-        // Check if it's a valid IP address
-        if (IPAddress.TryParse(address, out _))
-        {
-            return true;
-        }
-
-        // Check if it's a resolvable hostname
-        try
-        {
-            var hostEntry = Dns.GetHostEntry(address);
-            return true;
-        }
-        catch
-        {
-            // DNS resolution failed
-            return false;
-        }
-    }
+    private static bool IsValidAddress(string address) =>
+        !string.IsNullOrWhiteSpace(address) &&
+        IPAddress.TryParse(address, out _);
 }

--- a/VRCFaceTracking.Core/Services/OscRecvService.cs
+++ b/VRCFaceTracking.Core/Services/OscRecvService.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Net;
 using System.Net.Sockets;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -41,9 +42,20 @@ public class OscRecvService : BackgroundService
                 return;
             }
 
+            // Maybe remove the IsNullOrEmpty check since that is now being handeled by the Validator
             if (string.IsNullOrEmpty(_oscTarget.DestinationAddress) || _oscTarget.InPort == default)
             {
                 return;
+            }
+
+            var validationResults = new List<ValidationResult>();
+            var context = new ValidationContext(oscTarget);
+
+            if (!Validator.TryValidateObject(oscTarget, context, validationResults, true))
+            {
+                var errorMessages = string.Join(Environment.NewLine, validationResults.Select(vr => vr.ErrorMessage));
+                _logger.LogWarning($"{errorMessages} Reverting to default.");
+                oscTarget.DestinationAddress = "127.0.0.1";
             }
 
             UpdateTarget(new IPEndPoint(IPAddress.Parse(_oscTarget.DestinationAddress), _oscTarget.InPort));

--- a/VRCFaceTracking.Core/Services/OscRecvService.cs
+++ b/VRCFaceTracking.Core/Services/OscRecvService.cs
@@ -42,8 +42,7 @@ public class OscRecvService : BackgroundService
                 return;
             }
 
-            // Maybe remove the IsNullOrEmpty check since that is now being handeled by the Validator
-            if (string.IsNullOrEmpty(_oscTarget.DestinationAddress) || _oscTarget.InPort == default)
+            if (_oscTarget.InPort == default)
             {
                 return;
             }

--- a/VRCFaceTracking.Core/Services/OscSendService.cs
+++ b/VRCFaceTracking.Core/Services/OscSendService.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Net;
 using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
 using VRCFaceTracking.Core.Contracts;
@@ -37,9 +38,20 @@ public class OscSendService
                 return;
             }
 
+            // Maybe remove the IsNullOrEmpty check since that is now being handeled by the Validator
             if (string.IsNullOrEmpty(_oscTarget.DestinationAddress) || _oscTarget.OutPort == default)
             {
                 return;
+            }
+
+            var validationResults = new List<ValidationResult>();
+            var context = new ValidationContext(oscTarget);
+            
+            if (!Validator.TryValidateObject(oscTarget, context, validationResults, true))
+            {
+                var errorMessages = string.Join(Environment.NewLine, validationResults.Select(vr => vr.ErrorMessage));
+                _logger.LogWarning($"{errorMessages} reverting to default.");
+                oscTarget.DestinationAddress = "127.0.0.1";
             }
             
             UpdateTarget(new IPEndPoint(IPAddress.Parse(_oscTarget.DestinationAddress), _oscTarget.OutPort));

--- a/VRCFaceTracking.Core/Services/OscSendService.cs
+++ b/VRCFaceTracking.Core/Services/OscSendService.cs
@@ -38,8 +38,7 @@ public class OscSendService
                 return;
             }
 
-            // Maybe remove the IsNullOrEmpty check since that is now being handeled by the Validator
-            if (string.IsNullOrEmpty(_oscTarget.DestinationAddress) || _oscTarget.OutPort == default)
+            if (_oscTarget.OutPort == default)
             {
                 return;
             }

--- a/VRCFaceTracking.Core/Validation/ValidIpAddressAttribute.cs
+++ b/VRCFaceTracking.Core/Validation/ValidIpAddressAttribute.cs
@@ -10,6 +10,13 @@ public class ValidIpAddressAttribute : ValidationAttribute
     {
         if (value is string ipString)
         {
+
+            // Check for empty string
+            if (string.IsNullOrWhiteSpace(ipString))
+            {
+                return false;
+            }
+
             // Attempt to parse the IP address
             return IPAddress.TryParse(ipString, out _);
         }

--- a/VRCFaceTracking.Core/Validation/ValidIpAddressAttribute.cs
+++ b/VRCFaceTracking.Core/Validation/ValidIpAddressAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Net;
+
+namespace VRCFaceTracking.Core.Validation;
+
+public class ValidIpAddressAttribute : ValidationAttribute
+{
+    public override bool IsValid(object value)
+    {
+        if (value is string ipString)
+        {
+            // Attempt to parse the IP address
+            return IPAddress.TryParse(ipString, out _);
+        }
+
+        return false; // Return false if the value is not a string
+    }
+
+    public override string FormatErrorMessage(string name)
+    {
+        return $"{name} must be a valid IP address.";
+    }
+}

--- a/VRCFaceTracking/Views/SettingsPage.xaml
+++ b/VRCFaceTracking/Views/SettingsPage.xaml
@@ -61,7 +61,7 @@
                                 SmallChange="1"
                                 LargeChange="10"
                                 Margin="15, 0, 15, 0"
-                                Minimum="0"
+                                Minimum="1"
                                 Maximum="65535"
                                 Value="{x:Bind OscTarget.InPort, Mode=TwoWay}"/>
                             
@@ -75,7 +75,7 @@
                                 SpinButtonPlacementMode="Inline"
                                 SmallChange="1"
                                 LargeChange="10" 
-                                Minimum="0"
+                                Minimum="1"
                                 Maximum="65535"
                                 Margin="15, 0, 15, 0"
                                 Value="{x:Bind OscTarget.OutPort, Mode=TwoWay}"/>


### PR DESCRIPTION
When changing the ip address or port number to an invalid value on the next restart the app would crash do to the loaded invalid value'(s),

This pull requests checks if: the ip address is not blank or white space, the ip is an valid ip address, it is a resolvable hostname.
It also checks if the ports are not smaller than 1.

Let me know if the code needs any modifications.
