### PR TITLE
Adjust Binary Parameter values to be rounded by midpoint.

### DIFF
--- a/VRCFaceTracking.Core/OSC/DataTypes/BinaryBaseParameter.cs
+++ b/VRCFaceTracking.Core/OSC/DataTypes/BinaryBaseParameter.cs
@@ -21,7 +21,7 @@ public class BinaryBaseParameter : Parameter
         if (!_negativeParam.Relevant &&
             value < 0) // If the negative parameter isn't set, cut the negative values
             return false;
-        var adjustedValue = Math.Abs(value);
+        var adjustedValue = Math.Abs(value) + (1f / _maxPossibleBinaryInt);
         var bigValue = (int)(adjustedValue * (_maxPossibleBinaryInt - 1));
         return ((bigValue >> binaryIndex) & 1) == 1;
     }


### PR DESCRIPTION
Adjusts a probable oversight where Binary Parameter bits would always round down to now be based on the midpoint of the parameter bit.

Changed function:
```c#
// BinaryBaseParameter.cs
var adjustedValue = Math.Abs(value);
```
To:
```c#
// BinaryBaseParameter.cs
var adjustedValue = Math.Abs(value) + (1f / _maxPossibleBinaryInt);
```

Resolves #241 