### PR TITLE
Add head tracking data support

### DIFF
--- a/VRCFaceTracking.Core/AvatarConfigFileParser.cs
+++ b/VRCFaceTracking.Core/AvatarConfigFileParser.cs
@@ -68,7 +68,7 @@ public class AvatarConfigParser
         ParameterSenderService.Clear();
         var parameters = avatarConfig.parameters.Where(param => param.input != null).ToArray<IParameterDefinition>();
 
-        foreach (var parameter in UnifiedTracking.AllParameters_v2.Concat(UnifiedTracking.AllParameters_v1).ToArray())
+        foreach (var parameter in UnifiedTracking.AllParameters_v2.Concat(UnifiedTracking.AllParameters_v1).Concat(UnifiedTracking.HeadParameters).ToArray())
         {
             paramList.AddRange(parameter.ResetParam(parameters));
         }

--- a/VRCFaceTracking.Core/AvatarConfigFileParser.cs
+++ b/VRCFaceTracking.Core/AvatarConfigFileParser.cs
@@ -68,7 +68,7 @@ public class AvatarConfigParser
         ParameterSenderService.Clear();
         var parameters = avatarConfig.parameters.Where(param => param.input != null).ToArray<IParameterDefinition>();
 
-        foreach (var parameter in UnifiedTracking.AllParameters_v2.Concat(UnifiedTracking.AllParameters_v1).Concat(UnifiedTracking.HeadParameters).ToArray())
+        foreach (var parameter in UnifiedTracking.AllParameters)
         {
             paramList.AddRange(parameter.ResetParam(parameters));
         }

--- a/VRCFaceTracking.Core/OscQueryConfigParser.cs
+++ b/VRCFaceTracking.Core/OscQueryConfigParser.cs
@@ -52,8 +52,7 @@ public class OscQueryConfigParser
 
             // Reset all parameters
             var paramList = new List<Parameter>();
-            foreach (var parameter in UnifiedTracking.AllParameters_v2.Concat(UnifiedTracking.AllParameters_v1).Concat(UnifiedTracking.HeadParameters)
-                         .ToArray())
+            foreach (var parameter in UnifiedTracking.AllParameters)
             {
                 paramList.AddRange(parameter.ResetParam(avatarInfo.Parameters));
             }

--- a/VRCFaceTracking.Core/OscQueryConfigParser.cs
+++ b/VRCFaceTracking.Core/OscQueryConfigParser.cs
@@ -52,7 +52,7 @@ public class OscQueryConfigParser
 
             // Reset all parameters
             var paramList = new List<Parameter>();
-            foreach (var parameter in UnifiedTracking.AllParameters_v2.Concat(UnifiedTracking.AllParameters_v1)
+            foreach (var parameter in UnifiedTracking.AllParameters_v2.Concat(UnifiedTracking.AllParameters_v1).Concat(UnifiedTracking.HeadParameters)
                          .ToArray())
             {
                 paramList.AddRange(parameter.ResetParam(avatarInfo.Parameters));

--- a/VRCFaceTracking.Core/Params/Data/Mutation/Filter.cs
+++ b/VRCFaceTracking.Core/Params/Data/Mutation/Filter.cs
@@ -65,6 +65,13 @@ public class Filter : TrackingMutation
     EuroFilter opennessLeft;
     EuroFilter opennessRight;
 
+    EuroFilter headYaw;
+    EuroFilter headPitch;
+    EuroFilter headRoll;
+    EuroFilter headPosX;
+    EuroFilter headPosY;
+    EuroFilter headPosZ;
+
     public override string Name => "Data Filter";
 
     public override string Description => "Default data filtering for VRCFaceTracking expressions.";
@@ -85,6 +92,12 @@ public class Filter : TrackingMutation
         pupilRight = new();
         opennessLeft = new();
         opennessRight = new();
+        headYaw = new();
+        headPitch = new();
+        headRoll = new();
+        headPosX = new();
+        headPosY = new();
+        headPosZ = new();
 
         for (int i = 0; i < (int)UnifiedExpressions.Max; i++)
         {
@@ -106,5 +119,12 @@ public class Filter : TrackingMutation
         data.Eye.Right.PupilDiameter_MM = pupilRight.Filter(data.Eye.Right.PupilDiameter_MM);
         data.Eye.Right.Gaze.x = gazeRightX.Filter(data.Eye.Right.Gaze.x);
         data.Eye.Right.Gaze.y = gazeRightY.Filter(data.Eye.Right.Gaze.y);
+
+        data.Head.HeadYaw = headYaw.Filter(data.Head.HeadYaw);
+        data.Head.HeadPitch = headPitch.Filter(data.Head.HeadPitch);
+        data.Head.HeadRoll = headRoll.Filter(data.Head.HeadRoll);
+        data.Head.HeadPosX = headPosX.Filter(data.Head.HeadPosX);
+        data.Head.HeadPosY = headPosY.Filter(data.Head.HeadPosY);
+        data.Head.HeadPosZ = headPosZ.Filter(data.Head.HeadPosZ);
     }
 }

--- a/VRCFaceTracking.Core/Params/Data/Mutation/ParameterAdjustment.cs
+++ b/VRCFaceTracking.Core/Params/Data/Mutation/ParameterAdjustment.cs
@@ -45,6 +45,13 @@ public class ParameterAdjustment : TrackingMutation
     [MutationProperty("Tongue Directions")] public (float, float) tongueMove = new(0, 1);
     [MutationProperty("Tongue Miscellaneous")] public (float, float) tongueOther = new(0, 1);
 
+    [MutationProperty("Head Rotation (Side-to-Side)")] public (float, float) headRotationYaw = new(0, 1);
+    [MutationProperty("Head Rotation (Up-Down Tilt)")] public (float, float) headRotationPitch = new(0, 1);
+    [MutationProperty("Head Rotation (Side Tilt)")] public (float, float) headRotationRoll = new(0, 1);
+    [MutationProperty("Head Position (Side-to-Side)")] public (float, float) headPositionX = new(0, 1);
+    [MutationProperty("Head Position (Up-Down)")] public (float, float) headPositionY = new(0, 1);
+    [MutationProperty("Head Position (Forward-Back)")] public (float, float) headPositionZ = new(0, 1);
+
     public override string Name => "Parameter Adjustment";
 
     public override string Description => "Adjust VRCFaceTracking Parameters.";
@@ -54,6 +61,8 @@ public class ParameterAdjustment : TrackingMutation
     float Range(float value, float floor, float ceil) => (value - floor) / (ceil - floor);
 
     float SetRange(ref UnifiedExpressionShape shape, (float, float) ranges) => shape.Weight = Range(shape.Weight, ranges.Item1, ranges.Item2);
+    float SetRange(ref float value, (float, float) ranges) => value = Range(value, ranges.Item1, ranges.Item2);
+
 
     public override void MutateData(ref UnifiedTrackingData data)
     {
@@ -168,5 +177,13 @@ public class ParameterAdjustment : TrackingMutation
         SetRange(ref data.Shapes[(int)UnifiedExpressions.TongueFlat], tongueOther);
         SetRange(ref data.Shapes[(int)UnifiedExpressions.TongueSquish], tongueOther);
         SetRange(ref data.Shapes[(int)UnifiedExpressions.TongueRoll], tongueOther);
+
+        SetRange(ref data.Head.HeadYaw, headRotationYaw);
+        SetRange(ref data.Head.HeadPitch, headRotationPitch);
+        SetRange(ref data.Head.HeadRoll, headRotationRoll);
+
+        SetRange(ref data.Head.HeadPosX, headPositionX);
+        SetRange(ref data.Head.HeadPosY, headPositionY);
+        SetRange(ref data.Head.HeadPosZ, headPositionZ);
     }
 }

--- a/VRCFaceTracking.Core/Params/Data/UnifiedData.cs
+++ b/VRCFaceTracking.Core/Params/Data/UnifiedData.cs
@@ -87,10 +87,13 @@ namespace VRCFaceTracking.Core.Params.Data
     {
         /// <summary>
         /// Contains head rotation and position data.
+        /// Head coordinate system should be *LEFT handed, Y-up* (matching Unity coordinate system)
         /// Head rotation values should be normalized to a [-1, 1] range representing -90d to 90d rotation (0 meaning facing directly forwards)
+        ///     Yaw - Y axis rotation (positive values = looking right)
+        ///     Pitch - X axis rotation (positive values = looking down)
+        ///     Roll - Z axis rotation (positive values = side-tilt left)
         /// Head position values should be normalized / capped to a [-1, 1] range and represent deviation from a set user origin point in meters
         ///     The normalized values should be *approximately* represent a 1x1x1 meter movement region about the user's origin point 
-        ///     Head position coordinates should be *LEFT handed, Y-up* (matching Unity coordinate system)
         ///     (i.e. HeadPosX = 1 means the user is 0.5m to their right from their starting point, HeadPosX = -1 the user is 0.5m to their left)
         /// </summary>
         public float HeadYaw;

--- a/VRCFaceTracking.Core/Params/Data/UnifiedData.cs
+++ b/VRCFaceTracking.Core/Params/Data/UnifiedData.cs
@@ -83,6 +83,22 @@ namespace VRCFaceTracking.Core.Params.Data
         public float Weight;
     }
 
+    public struct UnifiedHeadData
+    {
+        /// <summary>
+        /// Contains head rotation and position data.
+        /// Head rotation values should be normalized to a [-1, 1] range representing -90d to 90d rotation
+        /// Head position values should be normalized / capped to a [-1, 1] range and represent deviation from user origin point
+        /// </summary>
+        public float HeadYaw;
+        public float HeadPitch;
+        public float HeadRoll;
+
+        public float HeadPosX;
+        public float HeadPosY;
+        public float HeadPosZ;
+    }
+
     /// <summary>
     /// All data that is accessible by modules and is output to parameters.
     /// </summary>
@@ -97,7 +113,7 @@ namespace VRCFaceTracking.Core.Params.Data
         /// Container of all Unified Expression expression data. 
         /// </summary>
         /// <remarks>
-        /// Example of useage:
+        /// Example of usage:
         /// <code>
         /// // Update JawOpen shape in Expression Data.
         /// Shapes[(int)UnifiedExpression.JawOpen].Weight = JawOpen;
@@ -105,11 +121,23 @@ namespace VRCFaceTracking.Core.Params.Data
         /// </remarks>
         public UnifiedExpressionShape[] Shapes = new UnifiedExpressionShape[(int)UnifiedExpressions.Max + 1];
 
+        /// <summary>
+        /// Container of head pose data.
+        /// </summary>
+        public UnifiedHeadData Head = new UnifiedHeadData();
+
         public void CopyPropertiesOf(UnifiedTrackingData data)
         {
             Eye.CopyPropertiesOf(data.Eye);
             for (int i = 0; i < Shapes.Length; i++)
                 Shapes[i].Weight = data.Shapes[i].Weight;
+            
+            Head.HeadYaw   = data.Head.HeadYaw;
+            Head.HeadPitch = data.Head.HeadPitch;
+            Head.HeadRoll  = data.Head.HeadRoll;
+            Head.HeadPosX  = data.Head.HeadPosX;
+            Head.HeadPosY  = data.Head.HeadPosY;
+            Head.HeadPosZ  = data.Head.HeadPosZ; 
         }
     }
 }

--- a/VRCFaceTracking.Core/Params/Data/UnifiedData.cs
+++ b/VRCFaceTracking.Core/Params/Data/UnifiedData.cs
@@ -87,8 +87,11 @@ namespace VRCFaceTracking.Core.Params.Data
     {
         /// <summary>
         /// Contains head rotation and position data.
-        /// Head rotation values should be normalized to a [-1, 1] range representing -90d to 90d rotation
-        /// Head position values should be normalized / capped to a [-1, 1] range and represent deviation from user origin point
+        /// Head rotation values should be normalized to a [-1, 1] range representing -90d to 90d rotation (0 meaning facing directly forwards)
+        /// Head position values should be normalized / capped to a [-1, 1] range and represent deviation from a set user origin point in meters
+        ///     The normalized values should be *approximately* represent a 1x1x1 meter movement region about the user's origin point 
+        ///     Head position coordinates should be *LEFT handed, Y-up* (matching Unity coordinate system)
+        ///     (i.e. HeadPosX = 1 means the user is 0.5m to their right from their starting point, HeadPosX = -1 the user is 0.5m to their left)
         /// </summary>
         public float HeadYaw;
         public float HeadPitch;

--- a/VRCFaceTracking.Core/Params/Expressions/UnifiedHeadParameters.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/UnifiedHeadParameters.cs
@@ -1,0 +1,23 @@
+﻿using VRCFaceTracking.Core.Params.DataTypes;
+
+namespace VRCFaceTracking.Core.Params.Expressions;
+public static class UnifiedHeadParameters
+{
+    public static readonly Parameter[] HeadParameters = {
+        #region Rotation
+
+        new EParam("v2/Head/Yaw", exp => exp.Head.HeadYaw),
+        new EParam("v2/Head/Pitch", exp => exp.Head.HeadPitch),
+        new EParam("v2/Head/Roll", exp => exp.Head.HeadRoll),
+
+        #endregion 
+
+        #region Position
+
+        new EParam("v2/Head/PosX", exp => exp.Head.HeadPosX),
+        new EParam("v2/Head/PosY", exp => exp.Head.HeadPosY),
+        new EParam("v2/Head/PosZ", exp => exp.Head.HeadPosZ)
+
+        #endregion
+    };
+}

--- a/VRCFaceTracking.Core/Services/ParameterSenderService.cs
+++ b/VRCFaceTracking.Core/Services/ParameterSenderService.cs
@@ -24,7 +24,7 @@ public class ParameterSenderService : BackgroundService
             if (AllParametersRelevantStatic == value) return;
             AllParametersRelevantStatic = value;
             SendQueue.Clear();
-            foreach (var parameter in UnifiedTracking.AllParameters_v2.Concat(UnifiedTracking.AllParameters_v1).Concat(UnifiedTracking.HeadParameters).ToArray())
+            foreach (var parameter in UnifiedTracking.AllParameters)
             {
                 parameter.ResetParam(Array.Empty<IParameterDefinition>());
             }

--- a/VRCFaceTracking.Core/Services/ParameterSenderService.cs
+++ b/VRCFaceTracking.Core/Services/ParameterSenderService.cs
@@ -24,7 +24,7 @@ public class ParameterSenderService : BackgroundService
             if (AllParametersRelevantStatic == value) return;
             AllParametersRelevantStatic = value;
             SendQueue.Clear();
-            foreach (var parameter in UnifiedTracking.AllParameters_v2.Concat(UnifiedTracking.AllParameters_v1).ToArray())
+            foreach (var parameter in UnifiedTracking.AllParameters_v2.Concat(UnifiedTracking.AllParameters_v1).Concat(UnifiedTracking.HeadParameters).ToArray())
             {
                 parameter.ResetParam(Array.Empty<IParameterDefinition>());
             }

--- a/VRCFaceTracking.Core/UnifiedTracking.cs
+++ b/VRCFaceTracking.Core/UnifiedTracking.cs
@@ -44,6 +44,11 @@ namespace VRCFaceTracking
         /// Version 2 (Unified Expressions) of all accessible output parameters.
         /// </summary>
         public static readonly Parameter[] AllParameters_v2 = UnifiedExpressionsParameters.ExpressionParameters;
+
+        /// <summary>
+        /// Head tracking parameters
+        /// </summary>
+        public static readonly Parameter[] HeadParameters = UnifiedHeadParameters.HeadParameters;
 #pragma warning restore CS0618
 
         /// <summary>

--- a/VRCFaceTracking.Core/UnifiedTracking.cs
+++ b/VRCFaceTracking.Core/UnifiedTracking.cs
@@ -49,6 +49,11 @@ namespace VRCFaceTracking
         /// Head tracking parameters
         /// </summary>
         public static readonly Parameter[] HeadParameters = UnifiedHeadParameters.HeadParameters;
+
+        /// <summary> 
+        /// The collection of EVERY possible output parameter
+        /// </summary>
+        public static readonly Parameter[] AllParameters = AllParameters_v2.Concat(AllParameters_v1).Concat(HeadParameters).ToArray();
 #pragma warning restore CS0618
 
         /// <summary>


### PR DESCRIPTION
Gives VRCFT the ability to support desktop "VTubing" using specially set-up avatars with 6 new internal parameters

```
v2/Head/Yaw
v2/Head/Pitch
v2/Head/Roll
v2/Head/PosX
v2/Head/PosY
v2/Head/PosZ
```

Any "desktop" face-tracking application already provides at least rotation data, and existing modules can easily be adapted to provide these data points. 

Example videos: 

https://github.com/user-attachments/assets/61fab05c-f269-427f-94e8-7d72b0caf3ea

---

https://github.com/user-attachments/assets/314e3d36-930e-4a9e-aa67-2e4197f5de39

