### PR TITLE
fix(mutator): Fix MouthOpen not animating lower left side with parameter adjustments

### DIFF
--- a/VRCFaceTracking.Core/Params/Data/Mutation/ParameterAdjustment.cs
+++ b/VRCFaceTracking.Core/Params/Data/Mutation/ParameterAdjustment.cs
@@ -121,9 +121,9 @@ public class ParameterAdjustment : TrackingMutation
 
         SetRange(ref data.Shapes[(int)UnifiedExpressions.MouthUpperDeepenLeft], mouthOpener);
         SetRange(ref data.Shapes[(int)UnifiedExpressions.MouthUpperDeepenRight], mouthOpener);
-        SetRange(ref data.Shapes[(int)UnifiedExpressions.MouthUpperUpRight], mouthOpener);
         SetRange(ref data.Shapes[(int)UnifiedExpressions.MouthUpperUpLeft], mouthOpener);
-        SetRange(ref data.Shapes[(int)UnifiedExpressions.MouthLowerDownRight], mouthOpener);
+        SetRange(ref data.Shapes[(int)UnifiedExpressions.MouthUpperUpRight], mouthOpener);
+        SetRange(ref data.Shapes[(int)UnifiedExpressions.MouthLowerDownLeft], mouthOpener);
         SetRange(ref data.Shapes[(int)UnifiedExpressions.MouthLowerDownRight], mouthOpener);
 
         SetRange(ref data.Shapes[(int)UnifiedExpressions.MouthCornerPullLeft], mouthSmile);


### PR DESCRIPTION
Obviously a typo.