### PR TITLE
Optimizations for parsing and receiving OSC messages from recv.

### DIFF
--- a/VRCFaceTracking.Core/OSC/OSCMessage.cs
+++ b/VRCFaceTracking.Core/OSC/OSCMessage.cs
@@ -98,8 +98,19 @@ public class OscMessage
         _metaPtr = fti_osc.parse_osc(bytes, len, ref messageIndex);
         if (_metaPtr != IntPtr.Zero)
         {
-            _meta = Marshal.PtrToStructure<OscMessageMeta>(_metaPtr);
+            //var meta1 = Marshal.PtrToStructure<OscMessageMeta>(_metaPtr);
+            ParseToOscMessageMeta(_metaPtr);
         }
+    }
+    private void ParseToOscMessageMeta(IntPtr ptr)
+    {
+        _meta.Address = Marshal.PtrToStringAnsi(Marshal.ReadIntPtr(ptr));
+        ptr += IntPtr.Size;
+
+        _meta.ValueLength = Marshal.ReadInt32(ptr);
+        ptr += IntPtr.Size;
+
+        _meta.Value = Marshal.ReadIntPtr(ptr);
     }
 
     /// <summary>

--- a/VRCFaceTracking.Core/Services/OscRecvService.cs
+++ b/VRCFaceTracking.Core/Services/OscRecvService.cs
@@ -16,7 +16,7 @@ public class OscRecvService : BackgroundService
     private readonly ILocalSettingsService _settingsService;
     
     private Socket _recvSocket;
-    private readonly byte[] _recvBuffer = new byte[4096];
+    private readonly byte[] _recvBuffer = new byte[64];
     
     private CancellationTokenSource _cts, _linkedToken;
     private CancellationToken _stoppingToken;

--- a/VRCFaceTracking.Core/Services/OscRecvService.cs
+++ b/VRCFaceTracking.Core/Services/OscRecvService.cs
@@ -108,29 +108,34 @@ public class OscRecvService : BackgroundService
                 continue;
             }
 
-            try
+            if (_recvSocket.Available > 0)
             {
-                var bytesReceived = await _recvSocket.ReceiveAsync(_recvBuffer, _linkedToken.Token);
-                var offset = 0;
-                var newMsg = OscMessage.TryParseOsc(_recvBuffer, bytesReceived, ref offset);
-                if (newMsg == null)
+                try
                 {
-                    continue;
-                }
+                    var bytesReceived = await _recvSocket.ReceiveAsync(_recvBuffer, SocketFlags.None, _linkedToken.Token);
+                    var offset = 0;
+                    var newMsg = OscMessage.TryParseOsc(_recvBuffer, bytesReceived, ref offset);
+                    if (newMsg == null)
+                    {
+                        continue;
+                    }
 
-                OnMessageReceived(newMsg);
-            }
-            catch (Exception e)
-            {
-                // We don't care about operation cancellations as they're intentional and carefully controlled
-                if (e.GetType() == typeof(OperationCanceledException))
-                {
-                    continue;
+                    OnMessageReceived(newMsg);
                 }
-                
-                _logger.LogError("Error encountered in OSC Receive thread: {e}", e);
-                SentrySdk.CaptureException(e, scope => scope.SetExtra("recvBuffer", _recvBuffer));
+                catch (Exception e)
+                {
+                    // We don't care about operation cancellations as they're intentional and carefully controlled
+                    if (e.GetType() == typeof(OperationCanceledException))
+                    {
+                        continue;
+                    }
+
+                    _logger.LogError("Error encountered in OSC Receive thread: {e}", e);
+                    SentrySdk.CaptureException(e, scope => scope.SetExtra("recvBuffer", _recvBuffer));
+                }
             }
+            else
+                await Task.Delay(100, _linkedToken.Token);
         }
     }
 }

--- a/VRCFaceTracking.Core/Services/OscRecvService.cs
+++ b/VRCFaceTracking.Core/Services/OscRecvService.cs
@@ -112,7 +112,7 @@ public class OscRecvService : BackgroundService
             {
                 var bytesReceived = await _recvSocket.ReceiveAsync(_recvBuffer, _linkedToken.Token);
                 var offset = 0;
-                var newMsg = await Task.Run(() => OscMessage.TryParseOsc(_recvBuffer, bytesReceived, ref offset), stoppingToken);
+                var newMsg = OscMessage.TryParseOsc(_recvBuffer, bytesReceived, ref offset);
                 if (newMsg == null)
                 {
                     continue;


### PR DESCRIPTION
Simple as it sounds. There are a few more optimizations that I want to explore but these already give a huge performance bump!

Some points that I want to address:
* Is it possible to omit specific `/avatar/parameters/*` from being sent over the socket? We don't really need to track face tracking parameters outside of the toggles.
* The way the datagrams are sent to the socket, it isn't really possible to parse it into a big packet and parse as a bundle.

I guess it's just typical VRChat OSC jank 😅.