### PR TITLE
Mockup for linearly normalized eye gaze values

### DIFF
--- a/VRCFaceTracking.Core/Params/Expressions/UnifiedExpressionsParameters.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/UnifiedExpressionsParameters.cs
@@ -28,6 +28,10 @@ public static class UnifiedExpressionsParameters
         new EParam("v2/Eye", exp => exp.Eye.Combined().Gaze),
         new EParam("v2/EyeLeft", exp => exp.Eye.Left.Gaze),
         new EParam("v2/EyeRight", exp => exp.Eye.Right.Gaze),
+
+        new EParam("v2/EyeLinear", exp => exp.Eye.Combined().Gaze.ToNormalized()),
+        new EParam("v2/EyeLeftLinear", exp => exp.Eye.Left.Gaze.ToNormalized()),
+        new EParam("v2/EyeRightLinear", exp => exp.Eye.Right.Gaze.ToNormalized()),
         
         // Use when tracking interface is sending verbose gaze data.
         new NativeParameter<Vector2>(exp =>

--- a/VRCFaceTracking.Core/Types/Vector2.cs
+++ b/VRCFaceTracking.Core/Types/Vector2.cs
@@ -48,5 +48,26 @@ namespace VRCFaceTracking.Core.Types
 
         public float ToPitch()
         => -(float)(Math.Atan(y) * (180 / Math.PI));
+
+        /// <summary>
+        /// Converts the Tobii normalized eye value to a normalized yaw value from -1 to 1, representing -45 to 45 degrees.
+        /// </summary>
+        public float ToNormalizedYaw()
+        => Remap(ToYaw(), -45, 45, -1, 1);
+
+        /// <summary>
+        /// Converts the Tobii normalized eye value to a normalized pitch value from -1 to 1, representing -45 to 45 degrees.
+        /// </summary>
+        public float ToNormalizedPitch()
+        => Remap(ToPitch(), -45, 45, -1, 1);
+
+        //return a remade vector2 that represents the remapped values
+        public Vector2 ToNormalized()
+        => new Vector2(ToNormalizedYaw(), ToNormalizedPitch());
+
+        private float Remap(float source, float sourceFrom, float sourceTo, float targetFrom, float targetTo)
+        {
+            return targetFrom + (source-sourceFrom)*(targetTo-targetFrom)/(sourceTo-sourceFrom);
+        }
     }
 }


### PR DESCRIPTION
This is a mockup for resolving this issue in the docs https://github.com/VRCFaceTracking/docs/pull/76

THe main problem is the eye gaze information is not actually linear, leading to it being kind of difficult to make accurate animations from it, as you can have up to a 4 degree offset from what the real value should be. This should resolve it. Let me know if any of the formatting here should be different or whatnot, first time contributing to this project. I cannot figure out how to build the project yet so I'm unsure if this produces the entire desired affect