### PR TITLE
fix(osc): only read the OSC JSON config if oscquery isn't in use

### DIFF
--- a/VRCFaceTracking.Core/Services/OscQueryService.cs
+++ b/VRCFaceTracking.Core/Services/OscQueryService.cs
@@ -81,7 +81,7 @@ public partial class OscQueryService(
     private async void HandleNewAvatar(string newId = null)
     {
         (IAvatarInfo avatarInfo, List<Parameter> relevantParameters)? newAvatar;
-        if (newId == null)
+        if (multicastDnsService.VrchatClientEndpoint != null)
         {
             newAvatar = await oscQueryConfigParser.ParseAvatar("");
         }


### PR DESCRIPTION
In #215 the behavior of parameter loading was adjusted to use the OSC JSON config if an avatar change was triggered from the `/avatar/change` OSC message. This allows things like av3emulator to work, but introduces a regression because VRCFT will now only load the parameter list from oscquery on initial startup. Future avatar changes are instead loaded from the OSC configs, with all of the associated pitfalls (resetting OSC configs, etc). 

Additionally, ChilloutVR is adding oscquery support, and this is a blocker for VRCFT to work for them due to the OSC configs being VRChat specific.

This change will revert to using oscquery for parameter loading iff VRChat-compatible oscquery is detected. This was successfully tested on:

1. VRChat stable with oscquery
2. ChilloutVR nightly with oscquery
3. av3emulator 3.4.9 with traditional OSC