### PR TITLE
accept requests from vrchat targeting http host '127.0.0.1'

### DIFF
--- a/VRCFaceTracking.Core/OSC/Query/HttpHandler.cs
+++ b/VRCFaceTracking.Core/OSC/Query/HttpHandler.cs
@@ -23,6 +23,7 @@ public class HttpHandler(IOscTarget oscTarget, ILogger<HttpHandler> logger) : ID
         _listener.Stop();
         _listener.Prefixes.Clear();
         _listener.Prefixes.Add(uri);
+        _listener.Prefixes.Add(uri.Replace("localhost", "127.0.0.1"));
         _listener.Start();
         _contextListenerResult = _listener.BeginGetContext(HttpListenerLoop, _listener);
     }


### PR DESCRIPTION
https://github.com/benaclejames/VRCFaceTracking/commit/7db279ee7866cf3f0e7f5fc04a4e0bdf0414dfd9 causes the HttpListener to reject any HTTP requests that don't target the HTTP host "localhost", including VRChat's requests to "127.0.0.1". This results in VRChat failing to connect to the UDP OSC receiver in VRCFT, resulting in us no longer receiving avatar change events.

This PR just adds 127.0.0.1 to the accepted host list alongside localhost. 

Discovery/context in https://discord.com/channels/849300336128032789/1427871375690829946 .