### PR TITLE
321: Fixes preview images

### DIFF
--- a/VRCFaceTracking.Core/Sandboxing/IPC/ReplyInitPacket.cs
+++ b/VRCFaceTracking.Core/Sandboxing/IPC/ReplyInitPacket.cs
@@ -95,6 +95,7 @@ public class ReplyInitPacket : IpcPacket
             imageStream.Position = 0;
         
             IconDataStreams.Add(imageStream);
+            offset += 4 + imageStreamSize;
         }
     }
 


### PR DESCRIPTION
Increments the offset when decoding the IPC packet when processing modules and encountering an image stream, to fix the issue where the SRanipal module (which uses two image streams as the hardware images) was displaying the same image twice (HMD and HMD instead of HMD and Face Tracker)