### PR TITLE
Fixing PR build error

### DIFF
--- a/VRCFaceTracking.Core/OSC/DataTypes/BinaryBaseParameter.cs
+++ b/VRCFaceTracking.Core/OSC/DataTypes/BinaryBaseParameter.cs
@@ -64,7 +64,7 @@ public class BinaryBaseParameter : Parameter
         {
             var tempName = param.Name;
             if (!int.TryParse(
-                    String.Concat(tempName.Replace(_paramName, "").ToArray().Reverse().TakeWhile(char.IsNumber)
+                    string.Concat(tempName.Replace(_paramName, "").Reverse().TakeWhile(char.IsNumber)
                         .Reverse()), out var index)) continue;
             // Get the shift steps
             var binaryIndex = GetBinarySteps(index);


### PR DESCRIPTION
Explicitly using System.Linq to force .Reverse() on line 67 to resolve, rather than the `void` that happens in PR building