### PR TITLE
fix(osc): re-emit all face params after avatar change to bridge animator-spawn race

### DIFF
--- a/VRCFaceTracking.Core/OSC/DataTypes/BaseParameter.cs
+++ b/VRCFaceTracking.Core/OSC/DataTypes/BaseParameter.cs
@@ -116,6 +116,9 @@ public class BaseParam<T> : Parameter where T : struct
 
     public override bool Deprecated => !_paramName.StartsWith(CurrentVersionPrefix);
 
+    // Force the next ParamValue assignment to enqueue regardless of value-equality dedup.
+    public override void MarkDirty() => _lastValue = null;
+
     protected virtual void Process(UnifiedTrackingData data) => ParamValue = _getValueFunc.Invoke(data);
 
     ~BaseParam()

--- a/VRCFaceTracking.Core/OSC/DataTypes/BinaryBaseParameter.cs
+++ b/VRCFaceTracking.Core/OSC/DataTypes/BinaryBaseParameter.cs
@@ -92,6 +92,12 @@ public class BinaryBaseParameter : Parameter
     public override (string, Parameter)[] GetParamNames() =>
         _params.SelectMany(p => p.GetParamNames()).Concat(_negativeParam.GetParamNames()).ToArray();
 
+    public override void MarkDirty()
+    {
+        _negativeParam.MarkDirty();
+        foreach (var p in _params) p.MarkDirty();
+    }
+
     public new bool Deprecated => false; // Handled by our children
 
     // This serves both as a test to make sure this index is in the binary sequence, but also returns how many bits we need to shift to find it

--- a/VRCFaceTracking.Core/Params/DataTypes/ParamContainers.cs
+++ b/VRCFaceTracking.Core/Params/DataTypes/ParamContainers.cs
@@ -113,4 +113,9 @@ public class EParam : Parameter
     public override Parameter[] ResetParam(IParameterDefinition[] newParams) => _parameter.SelectMany(param => param.ResetParam(newParams)).ToArray();
 
     public override (string, Parameter)[] GetParamNames() => _parameter.SelectMany(param => param.GetParamNames()).ToArray();
+
+    public override void MarkDirty()
+    {
+        foreach (var p in _parameter) p.MarkDirty();
+    }
 }

--- a/VRCFaceTracking.Core/Params/Parameter.cs
+++ b/VRCFaceTracking.Core/Params/Parameter.cs
@@ -8,5 +8,10 @@ namespace VRCFaceTracking.Core.Params
         public abstract (string paramName, Parameter paramLiteral)[] GetParamNames();
 
         public virtual bool Deprecated => false;
+
+        // Mark this parameter as needing a fresh emit on the next data tick. Default no-op;
+        // overridden by leaf parameters (BaseParam<T>) to clear their value-equality cache so
+        // the dedup short-circuit in the value setter does not swallow the next update.
+        public virtual void MarkDirty() { }
     }
 }

--- a/VRCFaceTracking.Core/Services/OscQueryService.cs
+++ b/VRCFaceTracking.Core/Services/OscQueryService.cs
@@ -103,6 +103,14 @@ public partial class OscQueryService(
             AvatarInfo = newAvatar.Value.avatarInfo;
             AvatarParameters = newAvatar.Value.relevantParameters;
         });
+
+        // Bridge VRChat's animator-spawn race on avatar change. The freshly spawned animator
+        // on the new avatar receives no FT-driven values until something changes, because the
+        // value-equality dedup in BaseParam<T>'s setter short-circuits identical-to-previous
+        // updates. Mark every relevant face parameter dirty so the next sender tick emits a
+        // full baseline bundle. One walk over UnifiedTracking.AllParameters per (rare) avatar
+        // change; no steady-state hot-path cost.
+        foreach (var p in UnifiedTracking.AllParameters) p.MarkDirty();
     }
 
     private void HandleNewAvatarWrapper() => HandleNewAvatar(); // Helper func used in callbacks


### PR DESCRIPTION
## What

Re-emit all face-tracking parameters once after an avatar change so a freshly spawned VRChat animator gets a baseline.

## Why

I noticed that whenever I switched avatars in VRChat, sometimes face tracking would just be… dead on the new avatar. Eyes wouldn't blink, mouth wouldn't move, nothing. Switching back to the avatar VRCFT had booted with always brought it back. Recalibrating in-game also brought it back. So clearly the data was still flowing, the new avatar just never got it.

After staring at it for a while, here's what I think is happening:

`BaseParam<T>.ParamValue` (in `VRCFaceTracking.Core/OSC/DataTypes/BaseParameter.cs`) dedups assignments against `_lastValue`:

```csharp
if (value.Equals(_lastValue)) return;
...
_lastValue = value;
Enqueue();
```

That's a perfectly reasonable optimisation for the steady state — no point sending the same float twice in a row.

But on `/avatar/change`, `OscQueryService.HandleNewAvatar` (via `OscQueryConfigParser.ParseAvatar`) calls `ResetParam(newAvatarParams)` on every parameter, which updates `Relevant` and the `OscMessage.Address`, but **doesn't touch `_lastValue`**. So if my face is sitting at the same values it had a moment ago (which it usually is — you're looking at the avatar selector, not pulling expressions), the dedup short-circuit fires for every parameter and nothing gets enqueued. The new avatar's animator spawns, never receives a single FT-driven OSC message, and stays at default until *something* changes.

Most of the time you don't notice this because you blink or talk within a second of the swap and that one different value triggers the resend for that one shape. But on a still face it persists indefinitely, and even when it kicks in only the shape that changed gets through — the rest stay zero.

This is hardware-agnostic — it's purely the value-equality optimisation in `BaseParam<T>` colliding with the fact that `ResetParam` doesn't reset the cache. I'm on a Pico 4 Ultra Enterprise with the Pico FT module, but the offending code path is in Core.

## How

Add a `virtual void MarkDirty()` to `Parameter`. Default is a no-op. `BaseParam<T>` overrides it to null `_lastValue`. `BinaryBaseParameter` and `EParam` fan out to their children. After `HandleNewAvatar` swaps `AvatarParameters`, walk `UnifiedTracking.AllParameters` once and call `MarkDirty()` on each — that guarantees the next sender tick (≤10 ms later) emits a fresh full bundle for the new animator.

Files touched:

- `VRCFaceTracking.Core/Params/Parameter.cs` — add the virtual.
- `VRCFaceTracking.Core/OSC/DataTypes/BaseParameter.cs` — `_lastValue = null`.
- `VRCFaceTracking.Core/OSC/DataTypes/BinaryBaseParameter.cs` — fan-out.
- `VRCFaceTracking.Core/Params/DataTypes/ParamContainers.cs` — `EParam` fan-out.
- `VRCFaceTracking.Core/Services/OscQueryService.cs` — call site after the dispatcher run.

+27 lines, no deletions, builds clean against `master` (`4c58db6`).

## Cost

One extra tree-walk per avatar change (rare, user-initiated). On the next sender tick that produces one additional OSC bundle of ~120 messages — well within a single packet, negligible. **Zero cost on the steady-state hot path** — `MarkDirty()` is never called outside avatar-change.

## Repro on stock

1. Boot VRCFT on avatar A. Confirm tracking works.
2. Switch to avatar B in VRChat with as still a face as you can manage.
3. Avatar B's FT-driven shapes will sit at default. Smile / blink / open mouth — only that specific shape comes alive. Others stay at default.
4. Switch back to A → A works. Recalibrate in VRC's expression menu → B works.

With this PR, step 3's avatar B has full tracking from the first sender tick after the avatar-change message lands.

## Notes

- I couldn't find an existing issue describing this exactly. Closest was a few "tracking suddenly stopped" reports (#220 etc.) but they were closed without repro and don't necessarily describe the same thing. Happy to open a separate issue first if you'd prefer that workflow — I went ahead with the PR because the bug is verifiable from reading the code alone.
- Comment in `OscQueryService.HandleNewAvatar` explains the rationale for the next reader.
