### PR TITLE
Add optional Face Expression OSC helper output

### DIFF
--- a/VRCFaceTracking.Core/Contracts/Services/IDispatcherService.cs
+++ b/VRCFaceTracking.Core/Contracts/Services/IDispatcherService.cs
@@ -5,4 +5,9 @@
 public interface IDispatcherService
 {
     public void Run(Action action);
+
+    /// <summary>
+    /// Runs an action on the UI dispatcher and completes after the action has run.
+    /// </summary>
+    public Task RunAsync(Action action);
 }

--- a/VRCFaceTracking.Core/MainStandalone.cs
+++ b/VRCFaceTracking.Core/MainStandalone.cs
@@ -49,7 +49,7 @@ public class MainStandalone : IMainService
         _logger.LogDebug("Teardown complete. Awaiting exit...");
     }
 
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
     {
         VRChat.EnsureVRCOSCDirectory();
 
@@ -66,7 +66,7 @@ public class MainStandalone : IMainService
                     "If parameters do not update, please restart VRChat or manually enable OSC yourself in your avatar's expressions menu.");
         }
 
-        _mutator.Load();
+        await _mutator.LoadAsync().ConfigureAwait(false);
 
         // Begin main OSC update loop
         _logger.LogDebug("Starting OSC update loop...");
@@ -76,6 +76,5 @@ public class MainStandalone : IMainService
             Utils.TimeBeginPeriod(1);
         }
 
-        return Task.CompletedTask;
     }
 }

--- a/VRCFaceTracking.Core/Params/Data/Mutation/FaceExpressionOscOutput.cs
+++ b/VRCFaceTracking.Core/Params/Data/Mutation/FaceExpressionOscOutput.cs
@@ -1,0 +1,225 @@
+using System.Collections.ObjectModel;
+using Microsoft.Extensions.Logging;
+using VRCFaceTracking.Core.Params.Expressions;
+
+namespace VRCFaceTracking.Core.Params.Data.Mutation;
+
+/// <summary>
+/// Opt-in postprocessor that emits calibration-aware face expression helper OSC values.
+/// </summary>
+public sealed class FaceExpressionOscOutput : TrackingMutation
+{
+    private bool _isActive;
+
+    public override string Name => "Face Expression OSC Output";
+
+    public override string Description => "Outputs optional calibration-aware face expression helper parameters for VRChat OSC.";
+
+    public override MutationPriority Step => MutationPriority.Postprocessor;
+
+    public override int Order => 1000;
+
+    public override bool IsSaved => true;
+
+    public override bool IsActive
+    {
+        get => _isActive;
+        set
+        {
+            _isActive = value;
+            if (!value)
+            {
+                FaceExpressionOscRuntime.SetDisabled();
+            }
+
+            RefreshCalibrationComponents();
+        }
+    }
+
+    [MutationProperty("Joy Activation Threshold", true, 0f, 1f)]
+    public float joyActivationThreshold = 0.5f;
+
+    [MutationProperty("Angry Activation Threshold", true, 0f, 1f)]
+    public float angryActivationThreshold = 0.5f;
+
+    [MutationProperty("Sad Activation Threshold", true, 0f, 1f)]
+    public float sadActivationThreshold = 0.5f;
+
+    [MutationProperty("Surprise Activation Threshold", true, 0f, 1f)]
+    public float surpriseActivationThreshold = 0.5f;
+
+    [MutationProperty("Debug Logging", true)]
+    public bool debugLogging = false;
+
+    public FaceExpressionCalibrationData Calibration { get; set; } = new();
+
+    private readonly List<MutationStatus> _calibrationStatusComponents = new();
+
+    private readonly List<MutationStatusAction> _calibrationActionComponents = new();
+
+    public override void Initialize(UnifiedTrackingData data)
+    {
+        Calibration ??= new FaceExpressionCalibrationData();
+        Calibration.EnsureDefaults();
+        FaceExpressionOscRuntime.Register(this);
+        RefreshCalibrationComponents();
+
+        if (!IsActive)
+        {
+            FaceExpressionOscRuntime.SetDisabled();
+        }
+    }
+
+    public override void CreateProperties()
+    {
+        // Build calibration controls manually, then append reflection-generated settings.
+        _calibrationStatusComponents.Clear();
+        _calibrationActionComponents.Clear();
+
+        var settingComponents = MutationComponentFactory.CreateComponents(this);
+        var components = new ObservableCollection<IMutationComponent>();
+
+        components.Add(new MutationInfo(
+            "Make the target expression first, then press its Calibrate button and hold the expression for 1 second. This helper stays disabled until Neutral, Joy, Angry, Sad, and Surprise are all calibrated."));
+        AddStatus(components, "Calibration", () => IsCalibrationReady() ? "Ready" : "Required");
+        AddStatus(components, "Output", GetOutputStatus);
+        AddCalibrationAction(components, "Neutral", FaceExpression.Neutral);
+        AddCalibrationAction(components, "Joy", FaceExpression.Joy);
+        AddCalibrationAction(components, "Angry", FaceExpression.Angry);
+        AddCalibrationAction(components, "Sad", FaceExpression.Sad);
+        AddCalibrationAction(components, "Surprise", FaceExpression.Surprise);
+        components.Add(new MutationAction("Reset", ResetFaceExpressionCalibration, "Reset", dispatch: GetDispatch()));
+
+        foreach (var component in settingComponents)
+        {
+            components.Add(component);
+        }
+
+        Components = components;
+        RefreshCalibrationComponents();
+    }
+
+    public override void MutateData(ref UnifiedTrackingData data)
+    {
+        if (!IsActive)
+        {
+            FaceExpressionOscRuntime.SetDisabled();
+            return;
+        }
+
+        FaceExpressionOscRuntime.Update(data, this);
+    }
+
+    private void ResetFaceExpressionCalibration()
+    {
+        FaceExpressionOscRuntime.Register(this);
+        FaceExpressionOscRuntime.ResetCalibration();
+        _ = SaveSettingsAsync();
+    }
+
+    private void BeginCalibration(FaceExpression expression)
+    {
+        FaceExpressionOscRuntime.Register(this);
+
+        if (!IsActive)
+        {
+            Logger?.LogWarning("Face expression calibration requested while Face Expression OSC Output is disabled.");
+            return;
+        }
+
+        FaceExpressionOscRuntime.BeginCalibration(expression);
+    }
+
+    public void RefreshCalibrationComponents()
+    {
+        // These components derive their display state from calibration data and runtime enablement.
+        foreach (var status in _calibrationStatusComponents)
+        {
+            status.Refresh();
+        }
+
+        foreach (var action in _calibrationActionComponents)
+        {
+            action.Refresh();
+        }
+    }
+
+    private void AddStatus(ObservableCollection<IMutationComponent> components, string name, Func<string> getValue)
+    {
+        var status = new MutationStatus(name, getValue, GetDispatch());
+        _calibrationStatusComponents.Add(status);
+        components.Add(status);
+    }
+
+    private void AddCalibrationAction(
+        ObservableCollection<IMutationComponent> components,
+        string name,
+        FaceExpression expression)
+    {
+        var action = new MutationStatusAction(
+            name,
+            () => IsFaceExpressionCalibrated(expression) ? "Calibrated" : "Not calibrated",
+            () => IsFaceExpressionCalibrated(expression) ? "Recalibrate" : "Calibrate",
+            () => CanCalibrateFaceExpression(expression),
+            () => BeginCalibration(expression),
+            GetDispatch());
+
+        _calibrationActionComponents.Add(action);
+        components.Add(action);
+    }
+
+    private bool IsCalibrationReady()
+    {
+        return (Calibration ?? new FaceExpressionCalibrationData()).IsReadyForFaceExpressionOsc();
+    }
+
+    private string GetOutputStatus()
+    {
+        if (!IsActive)
+        {
+            return "Disabled";
+        }
+
+        return IsCalibrationReady() ? "Enabled" : "Waiting for calibration";
+    }
+
+    private bool IsFaceExpressionCalibrated(FaceExpression expression)
+    {
+        var calibration = Calibration ?? new FaceExpressionCalibrationData();
+        return expression == FaceExpression.Neutral
+            ? calibration.HasNeutralBaseline
+            : calibration.HasReference(expression);
+    }
+
+    private bool CanCalibrateFaceExpression(FaceExpression expression)
+    {
+        return IsActive;
+    }
+
+    public void RequestSave()
+    {
+        _ = SaveSettingsAsync();
+    }
+
+    private async Task SaveSettingsAsync()
+    {
+        if (LocalSettingsService == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await LocalSettingsService.SaveSettingAsync(Name, this, true);
+        }
+        catch (Exception ex)
+        {
+            Logger?.LogError(ex, "Failed to save face expression OSC settings.");
+        }
+    }
+
+    private Action<Action>? GetDispatch()
+    {
+        return DispatcherService == null ? null : action => DispatcherService.Run(action);
+    }
+}

--- a/VRCFaceTracking.Core/Params/Data/Mutation/TrackingMutation.cs
+++ b/VRCFaceTracking.Core/Params/Data/Mutation/TrackingMutation.cs
@@ -27,6 +27,8 @@ public abstract partial class TrackingMutation
     public abstract string Description { get; }
     public abstract MutationPriority Step { get; }
     [JsonIgnore]
+    public virtual int Order => 0;
+    [JsonIgnore]
     public ObservableCollection<IMutationComponent> Components { get; set; }
     public virtual bool IsSaved { get; } = false;
 
@@ -36,9 +38,11 @@ public abstract partial class TrackingMutation
     public ILogger Logger { get; set; }
     [JsonIgnore]
     public ILocalSettingsService LocalSettingsService { get; set; }
+    [JsonIgnore]
+    public IDispatcherService? DispatcherService { get; set; }
     public virtual void Initialize(UnifiedTrackingData data) { }
     public abstract void MutateData(ref UnifiedTrackingData data);
-    public void CreateProperties() => Components = MutationComponentFactory.CreateComponents(this);
+    public virtual void CreateProperties() => Components = MutationComponentFactory.CreateComponents(this);
     public static TrackingMutation[] GetImplementingMutations(bool ordered = true)
     {
         var types = Assembly.GetExecutingAssembly()
@@ -54,7 +58,11 @@ public abstract partial class TrackingMutation
 
         if (ordered)
         {
-            mutations.Sort((a, b) => a.Step.CompareTo(b.Step));
+            mutations.Sort((a, b) =>
+            {
+                var stepCompare = a.Step.CompareTo(b.Step);
+                return stepCompare != 0 ? stepCompare : a.Order.CompareTo(b.Order);
+            });
         }
 
         return mutations.ToArray();

--- a/VRCFaceTracking.Core/Params/Data/Mutation/UI/MutationComponents.cs
+++ b/VRCFaceTracking.Core/Params/Data/Mutation/UI/MutationComponents.cs
@@ -20,6 +20,19 @@ public interface IMutationComponent
     public string Name { get; }
 }
 
+/// <summary>
+/// Read-only informational row in a mutation settings panel.
+/// </summary>
+public class MutationInfo : IMutationComponent
+{
+    public MutationInfo(string name)
+    {
+        Name = name;
+    }
+
+    public string Name { get; }
+}
+
 public class MutationProperty : IMutationComponent, INotifyPropertyChanged
 {
     private object _value;
@@ -129,17 +142,161 @@ public class MutationRangeProperty : IMutationComponent, INotifyPropertyChanged
 public class MutationAction : IMutationComponent, ICommand
 {
     public string Name { get; }
+    public string ButtonText { get; }
     private readonly Action _execute;
+    private readonly Func<bool> _canExecute;
+    private readonly Action<Action>? _dispatch;
 
-    public MutationAction(string name, Action execute)
+    public MutationAction(
+        string name,
+        Action execute,
+        string? buttonText = null,
+        Func<bool>? canExecute = null,
+        Action<Action>? dispatch = null)
     {
         Name = name;
+        ButtonText = buttonText ?? name;
         _execute = execute;
+        _canExecute = canExecute ?? (() => true);
+        _dispatch = dispatch;
     }
 
-    public event EventHandler CanExecuteChanged;
+    public event EventHandler? CanExecuteChanged;
 
-    public bool CanExecute(object parameter) => true; // Adjust logic as needed
+    public bool CanExecute(object? parameter) => _canExecute();
 
-    public void Execute(object parameter) => Task.Run(() => _execute());
+    public void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter))
+        {
+            return;
+        }
+
+        Task.Run(() => _execute());
+    }
+
+    public void Refresh()
+    {
+        Dispatch(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty));
+    }
+
+    private void Dispatch(Action action)
+    {
+        if (_dispatch != null)
+        {
+            _dispatch(action);
+            return;
+        }
+
+        action();
+    }
+}
+
+/// <summary>
+/// Read-only status row whose value is supplied by a callback and refreshed on demand.
+/// </summary>
+public class MutationStatus : IMutationComponent, INotifyPropertyChanged
+{
+    private readonly Func<string> _getValue;
+    private readonly Action<Action>? _dispatch;
+
+    public MutationStatus(string name, Func<string> getValue, Action<Action>? dispatch = null)
+    {
+        Name = name;
+        _getValue = getValue;
+        _dispatch = dispatch;
+    }
+
+    public string Name { get; }
+
+    public string Value => _getValue();
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public void Refresh()
+    {
+        Dispatch(() => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value))));
+    }
+
+    private void Dispatch(Action action)
+    {
+        if (_dispatch != null)
+        {
+            _dispatch(action);
+            return;
+        }
+
+        action();
+    }
+}
+
+/// <summary>
+/// Combined status row and command button for stateful mutation actions.
+/// </summary>
+public class MutationStatusAction : IMutationComponent, ICommand, INotifyPropertyChanged
+{
+    private readonly Func<string> _getStatus;
+    private readonly Func<string> _getButtonText;
+    private readonly Func<bool> _canExecute;
+    private readonly Action _execute;
+    private readonly Action<Action>? _dispatch;
+
+    public MutationStatusAction(
+        string name,
+        Func<string> getStatus,
+        Func<string> getButtonText,
+        Func<bool> canExecute,
+        Action execute,
+        Action<Action>? dispatch = null)
+    {
+        Name = name;
+        _getStatus = getStatus;
+        _getButtonText = getButtonText;
+        _canExecute = canExecute;
+        _execute = execute;
+        _dispatch = dispatch;
+    }
+
+    public string Name { get; }
+
+    public string Status => _getStatus();
+
+    public string ButtonText => _getButtonText();
+
+    public event EventHandler? CanExecuteChanged;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute();
+
+    public void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter))
+        {
+            return;
+        }
+
+        Task.Run(() => _execute());
+    }
+
+    public void Refresh()
+    {
+        Dispatch(() =>
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Status)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ButtonText)));
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        });
+    }
+
+    private void Dispatch(Action action)
+    {
+        if (_dispatch != null)
+        {
+            _dispatch(action);
+            return;
+        }
+
+        action();
+    }
 }

--- a/VRCFaceTracking.Core/Params/Data/Mutation/UI/MutationFactory.cs
+++ b/VRCFaceTracking.Core/Params/Data/Mutation/UI/MutationFactory.cs
@@ -137,10 +137,17 @@ public static class MutationComponentFactory
             var attribute = method.GetCustomAttribute<MutationButtonAttribute>();
             if (attribute != null)
             {
+                Action<Action>? dispatch = null;
+                if (instance is TrackingMutation mutation && mutation.DispatcherService != null)
+                {
+                    dispatch = action => mutation.DispatcherService.Run(action);
+                }
+
                 var mutationProperty = new MutationAction
                 (
                     attribute.Name,
-                    () => method.Invoke(instance, null)
+                    () => method.Invoke(instance, null),
+                    dispatch: dispatch
                 );
                 components.Add(mutationProperty);
             }

--- a/VRCFaceTracking.Core/Params/Data/UnifiedTrackingMutator.cs
+++ b/VRCFaceTracking.Core/Params/Data/UnifiedTrackingMutator.cs
@@ -18,15 +18,20 @@ public partial class UnifiedTrackingMutator : ObservableObject
 
     private readonly ILogger<UnifiedTrackingMutator> _logger;
     private readonly ILocalSettingsService _localSettingsService;
+    private readonly IDispatcherService _dispatcherService;
     private readonly object _mutationsLock = new();
     private UnifiedTrackingData _inputBuffer;
     public ObservableCollection<TrackingMutation> _mutations = new();
 
-    public UnifiedTrackingMutator(ILogger<UnifiedTrackingMutator> logger, ILocalSettingsService localSettingsService)
+    public UnifiedTrackingMutator(
+        ILogger<UnifiedTrackingMutator> logger,
+        ILocalSettingsService localSettingsService,
+        IDispatcherService dispatcherService)
     {
         UnifiedTracking.Mutator = this;
         _logger = logger;
         _localSettingsService = localSettingsService;
+        _dispatcherService = dispatcherService;
             
         Enabled = false;
         _inputBuffer = new UnifiedTrackingData();
@@ -77,24 +82,10 @@ public partial class UnifiedTrackingMutator : ObservableObject
         _logger.LogDebug("Mutation data saved.");
     }
 
-    public void Initialize()
+    private async Task CreateMutation(TrackingMutation mutation)
     {
-        // Try to load config and propogate data into Unified if they exist.
-        _logger.LogDebug("Initializing mutations...");
-        lock (_mutationsLock)
-        {
-            foreach (var mutation in _mutations)
-            {
-                _logger.LogInformation($"Initializing {mutation.Name}");
-                mutation.Initialize(UnifiedTracking.Data);
-            }
-        }
+        TrackingMutation mutationToAdd = mutation;
 
-        _logger.LogDebug("Mutations initialized successfully.");
-    }
-    
-    private async void CreateMutation(TrackingMutation mutation) 
-    {
         try
         {
             _logger.LogInformation($"Loading {mutation.Name}");
@@ -111,38 +102,42 @@ public partial class UnifiedTrackingMutator : ObservableObject
             PropertyInfo resultProperty = task.GetType().GetProperty("Result");
             var typedMutation = resultProperty.GetValue(task);
 
-            mutation = (TrackingMutation)typedMutation;
-
-            mutation.Logger = _logger;
-            mutation.LocalSettingsService =  _localSettingsService;
-            mutation.CreateProperties();
-            _mutations.Add(mutation);
+            mutationToAdd = (TrackingMutation)typedMutation;
         }
         catch (Exception ex)
         {
             _logger.LogError($"Creating new mutation data. {ex.Message}");
-            mutation.Logger = _logger;
-            mutation.LocalSettingsService =  _localSettingsService;
-            mutation.CreateProperties();
         }
+
+        mutationToAdd.Logger = _logger;
+        mutationToAdd.LocalSettingsService =  _localSettingsService;
+        mutationToAdd.DispatcherService = _dispatcherService;
+
+        await _dispatcherService.RunAsync(() =>
+        {
+            mutationToAdd.CreateProperties();
+            _logger.LogInformation($"Initializing {mutationToAdd.Name}");
+            mutationToAdd.Initialize(UnifiedTracking.Data);
+
+            lock (_mutationsLock)
+            {
+                _mutations.Add(mutationToAdd);
+            }
+        }).ConfigureAwait(false);
     }
 
-    public async void Load()
+    public async Task LoadAsync()
     {
         // Try to load config and propogate data into Unified if they exist.
         _logger.LogDebug("Loading mutation data...");
         var mutations = TrackingMutation.GetImplementingMutations(true);
         await _localSettingsService.Load(this);
 
-        lock (_mutationsLock)
+        foreach (var mutation in mutations)
         {
-            foreach (var mutation in mutations)
-            {
-                CreateMutation(mutation);
-            }
+            await CreateMutation(mutation).ConfigureAwait(false);
         }
 
         _logger.LogDebug("Mutation data loaded.");
-        Initialize();
     }
 }

--- a/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpression.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpression.cs
@@ -1,0 +1,13 @@
+namespace VRCFaceTracking.Core.Params.Expressions;
+
+/// <summary>
+/// Face expression labels used by the optional helper OSC output.
+/// </summary>
+public enum FaceExpression
+{
+    Neutral = 0,
+    Joy = 1,
+    Angry = 2,
+    Sad = 3,
+    Surprise = 4,
+}

--- a/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionCalibrationData.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionCalibrationData.cs
@@ -1,0 +1,115 @@
+using System.Runtime.Serialization;
+
+namespace VRCFaceTracking.Core.Params.Expressions;
+
+/// <summary>
+/// Stores the user's neutral baseline and per-expression reference templates.
+/// </summary>
+public sealed class FaceExpressionCalibrationData
+{
+    public FaceExpressionFeatureVector NeutralBaseline { get; set; }
+
+    public bool HasNeutralBaseline { get; set; }
+
+    public FaceExpressionReferenceCalibrationData JoyReference { get; set; } = new();
+    public FaceExpressionReferenceCalibrationData AngryReference { get; set; } = new();
+    public FaceExpressionReferenceCalibrationData SadReference { get; set; } = new();
+    public FaceExpressionReferenceCalibrationData SurpriseReference { get; set; } = new();
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+    {
+        EnsureDefaults();
+    }
+
+    public bool IsReadyForFaceExpressionOsc()
+    {
+        return HasNeutralBaseline && HasCompleteFaceExpressionReferences();
+    }
+
+    /// <summary>
+    /// Checks every non-neutral template; the neutral baseline is checked by IsReadyForFaceExpressionOsc.
+    /// </summary>
+    public bool HasCompleteFaceExpressionReferences()
+    {
+        return JoyReference.HasReference &&
+            AngryReference.HasReference &&
+            SadReference.HasReference &&
+            SurpriseReference.HasReference;
+    }
+
+    public bool HasReference(FaceExpression expression)
+    {
+        return TryGetReference(expression)?.HasReference == true;
+    }
+
+    public FaceExpressionFeatureVector GetRawReference(FaceExpression expression)
+    {
+        return TryGetReference(expression)?.RawReference ?? default;
+    }
+
+    /// <summary>
+    /// Stores the caller-provided raw reference vector and its calibration sample count.
+    /// </summary>
+    public void SetRawReference(FaceExpression expression, FaceExpressionFeatureVector reference, int sampleCount)
+    {
+        EnsureDefaults();
+        var referenceData = TryGetReference(expression);
+        if (referenceData == null)
+        {
+            return;
+        }
+
+        referenceData.HasReference = true;
+        referenceData.SampleCount = Math.Max(sampleCount, 0);
+        referenceData.RawReference = reference;
+    }
+
+    public void Reset()
+    {
+        NeutralBaseline = default;
+        HasNeutralBaseline = false;
+        ClearFaceExpressionReferences();
+    }
+
+    public void ClearFaceExpressionReferences()
+    {
+        JoyReference = new FaceExpressionReferenceCalibrationData();
+        AngryReference = new FaceExpressionReferenceCalibrationData();
+        SadReference = new FaceExpressionReferenceCalibrationData();
+        SurpriseReference = new FaceExpressionReferenceCalibrationData();
+    }
+
+    public void EnsureDefaults()
+    {
+        JoyReference ??= new FaceExpressionReferenceCalibrationData();
+        AngryReference ??= new FaceExpressionReferenceCalibrationData();
+        SadReference ??= new FaceExpressionReferenceCalibrationData();
+        SurpriseReference ??= new FaceExpressionReferenceCalibrationData();
+    }
+
+    private FaceExpressionReferenceCalibrationData? TryGetReference(FaceExpression expression)
+    {
+        return expression switch
+        {
+            FaceExpression.Joy => JoyReference,
+            FaceExpression.Angry => AngryReference,
+            FaceExpression.Sad => SadReference,
+            FaceExpression.Surprise => SurpriseReference,
+            _ => null,
+        };
+    }
+}
+
+/// <summary>
+/// Calibration template and metadata for a single non-neutral expression.
+/// </summary>
+public sealed class FaceExpressionReferenceCalibrationData
+{
+    public bool HasReference { get; set; }
+
+    public int SampleCount { get; set; }
+
+    public FaceExpressionFeatureVector RawReference { get; set; }
+
+}

--- a/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionClassifier.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionClassifier.cs
@@ -1,0 +1,142 @@
+namespace VRCFaceTracking.Core.Params.Expressions;
+
+/// <summary>
+/// Final helper OSC classification result.
+/// </summary>
+public readonly record struct FaceExpressionResult(FaceExpression FaceExpression, int Index, float Power);
+
+/// <summary>
+/// Template similarity scores before thresholding and switch smoothing.
+/// </summary>
+public readonly record struct FaceExpressionRawScores(float Joy, float Angry, float Sad, float Surprise);
+
+/// <summary>
+/// Converts calibrated feature templates into expression scores and a selected label.
+/// </summary>
+public static class FaceExpressionClassifier
+{
+    private const float ReferenceMinNorm = 0.001f;
+
+    public static FaceExpressionRawScores GetReferenceScores(FaceExpressionFeatureVector rawFeatures, FaceExpressionCalibrationData calibration)
+    {
+        var features = calibration.HasNeutralBaseline
+            ? rawFeatures.SubtractBaseline(calibration.NeutralBaseline)
+            : rawFeatures;
+
+        return new FaceExpressionRawScores(
+            GetReferenceScore(features, GetReferenceDelta(calibration, FaceExpression.Joy)),
+            GetReferenceScore(features, GetReferenceDelta(calibration, FaceExpression.Angry)),
+            GetReferenceScore(features, GetReferenceDelta(calibration, FaceExpression.Sad)),
+            GetReferenceScore(features, GetReferenceDelta(calibration, FaceExpression.Surprise)));
+    }
+
+    public static FaceExpressionResult Classify(
+        FaceExpressionRawScores scores,
+        float joyActivationThreshold,
+        float angryActivationThreshold,
+        float sadActivationThreshold,
+        float surpriseActivationThreshold)
+    {
+        var expression = FaceExpression.Joy;
+        var maxScore = scores.Joy;
+        var activationThreshold = joyActivationThreshold;
+
+        if (scores.Angry > maxScore)
+        {
+            expression = FaceExpression.Angry;
+            maxScore = scores.Angry;
+            activationThreshold = angryActivationThreshold;
+        }
+
+        if (scores.Sad > maxScore)
+        {
+            expression = FaceExpression.Sad;
+            maxScore = scores.Sad;
+            activationThreshold = sadActivationThreshold;
+        }
+
+        if (scores.Surprise > maxScore)
+        {
+            expression = FaceExpression.Surprise;
+            maxScore = scores.Surprise;
+            activationThreshold = surpriseActivationThreshold;
+        }
+
+        if (maxScore < Math.Clamp(activationThreshold, 0f, 1f))
+        {
+            var neutralScore = Math.Clamp(1f - maxScore, 0f, 1f);
+            return new FaceExpressionResult(FaceExpression.Neutral, (int)FaceExpression.Neutral, neutralScore);
+        }
+
+        return new FaceExpressionResult(expression, (int)expression, Math.Clamp(maxScore, 0f, 1f));
+    }
+
+    public static float GetScoreForFaceExpression(FaceExpressionRawScores scores, FaceExpression expression)
+    {
+        return expression switch
+        {
+            FaceExpression.Joy => scores.Joy,
+            FaceExpression.Angry => scores.Angry,
+            FaceExpression.Sad => scores.Sad,
+            FaceExpression.Surprise => scores.Surprise,
+            _ => Math.Clamp(1f - Math.Max(Math.Max(scores.Joy, scores.Angry), Math.Max(scores.Sad, scores.Surprise)), 0f, 1f),
+        };
+    }
+
+    private static float GetReferenceScore(
+        FaceExpressionFeatureVector features,
+        FaceExpressionFeatureVector reference)
+    {
+        // Score by direction similarity, then scale down weak expressions that point the same way.
+        var currentNorm = GetVectorNorm(features);
+        var referenceNorm = GetVectorNorm(reference);
+        if (currentNorm < ReferenceMinNorm || referenceNorm < ReferenceMinNorm)
+        {
+            return 0f;
+        }
+
+        var cosine = GetDotProduct(features, reference) / (currentNorm * referenceNorm);
+        var strength = Math.Clamp(currentNorm / referenceNorm, 0f, 1f);
+        return ClampScore(cosine * strength);
+    }
+
+    private static FaceExpressionFeatureVector GetReferenceDelta(FaceExpressionCalibrationData calibration, FaceExpression expression)
+    {
+        var rawReference = calibration.GetRawReference(expression);
+        return calibration.HasNeutralBaseline
+            ? rawReference.SubtractBaseline(calibration.NeutralBaseline)
+            : rawReference;
+    }
+
+    private static float GetVectorNorm(FaceExpressionFeatureVector features)
+    {
+        return MathF.Sqrt(GetDotProduct(features, features));
+    }
+
+    private static float GetDotProduct(
+        FaceExpressionFeatureVector left,
+        FaceExpressionFeatureVector right)
+    {
+        return
+            Product(left.Smile, right.Smile) +
+            Product(left.SadMouth, right.SadMouth) +
+            Product(left.BrowDown, right.BrowDown) +
+            Product(left.BrowUp, right.BrowUp) +
+            Product(left.BrowInnerUp, right.BrowInnerUp) +
+            Product(left.EyeWide, right.EyeWide) +
+            Product(left.EyeSquint, right.EyeSquint) +
+            Product(left.CheekSquint, right.CheekSquint) +
+            Product(left.MouthOpen, right.MouthOpen) +
+            Product(left.JawOpen, right.JawOpen) +
+            Product(left.MouthPress, right.MouthPress) +
+            Product(left.MouthTightener, right.MouthTightener) +
+            Product(left.NoseSneer, right.NoseSneer);
+    }
+
+    private static float Product(float left, float right)
+    {
+        return Math.Clamp(left, 0f, 1f) * Math.Clamp(right, 0f, 1f);
+    }
+
+    private static float ClampScore(float score) => Math.Clamp(score, 0f, 1f);
+}

--- a/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionFeatureVector.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionFeatureVector.cs
@@ -1,0 +1,183 @@
+using VRCFaceTracking.Core.Params.Data;
+
+namespace VRCFaceTracking.Core.Params.Expressions;
+
+/// <summary>
+/// Reduced set of expression features used for calibration and template matching.
+/// </summary>
+public struct FaceExpressionFeatureVector
+{
+    public float Smile { get; set; }
+    public float SadMouth { get; set; }
+    public float BrowDown { get; set; }
+    public float BrowUp { get; set; }
+    public float BrowInnerUp { get; set; }
+    public float EyeWide { get; set; }
+    public float EyeSquint { get; set; }
+    public float CheekSquint { get; set; }
+    public float MouthOpen { get; set; }
+    public float JawOpen { get; set; }
+    public float MouthPress { get; set; }
+    public float MouthTightener { get; set; }
+    public float NoseSneer { get; set; }
+
+    public void Add(FaceExpressionFeatureVector other)
+    {
+        Smile += other.Smile;
+        SadMouth += other.SadMouth;
+        BrowDown += other.BrowDown;
+        BrowUp += other.BrowUp;
+        BrowInnerUp += other.BrowInnerUp;
+        EyeWide += other.EyeWide;
+        EyeSquint += other.EyeSquint;
+        CheekSquint += other.CheekSquint;
+        MouthOpen += other.MouthOpen;
+        JawOpen += other.JawOpen;
+        MouthPress += other.MouthPress;
+        MouthTightener += other.MouthTightener;
+        NoseSneer += other.NoseSneer;
+    }
+
+    public FaceExpressionFeatureVector Divide(float divisor)
+    {
+        if (divisor <= 0f)
+        {
+            return this;
+        }
+
+        return new FaceExpressionFeatureVector
+        {
+            Smile = Smile / divisor,
+            SadMouth = SadMouth / divisor,
+            BrowDown = BrowDown / divisor,
+            BrowUp = BrowUp / divisor,
+            BrowInnerUp = BrowInnerUp / divisor,
+            EyeWide = EyeWide / divisor,
+            EyeSquint = EyeSquint / divisor,
+            CheekSquint = CheekSquint / divisor,
+            MouthOpen = MouthOpen / divisor,
+            JawOpen = JawOpen / divisor,
+            MouthPress = MouthPress / divisor,
+            MouthTightener = MouthTightener / divisor,
+            NoseSneer = NoseSneer / divisor,
+        };
+    }
+
+    public FaceExpressionFeatureVector SubtractBaseline(FaceExpressionFeatureVector baseline)
+    {
+        // Baseline subtraction keeps only expression movement above the user's neutral face.
+        return new FaceExpressionFeatureVector
+        {
+            Smile = ClampPositive(Smile - baseline.Smile),
+            SadMouth = ClampPositive(SadMouth - baseline.SadMouth),
+            BrowDown = ClampPositive(BrowDown - baseline.BrowDown),
+            BrowUp = ClampPositive(BrowUp - baseline.BrowUp),
+            BrowInnerUp = ClampPositive(BrowInnerUp - baseline.BrowInnerUp),
+            EyeWide = ClampPositive(EyeWide - baseline.EyeWide),
+            EyeSquint = ClampPositive(EyeSquint - baseline.EyeSquint),
+            CheekSquint = ClampPositive(CheekSquint - baseline.CheekSquint),
+            MouthOpen = ClampPositive(MouthOpen - baseline.MouthOpen),
+            JawOpen = ClampPositive(JawOpen - baseline.JawOpen),
+            MouthPress = ClampPositive(MouthPress - baseline.MouthPress),
+            MouthTightener = ClampPositive(MouthTightener - baseline.MouthTightener),
+            NoseSneer = ClampPositive(NoseSneer - baseline.NoseSneer),
+        };
+    }
+
+    private static float ClampPositive(float value) => Math.Clamp(value, 0f, 1f);
+}
+
+/// <summary>
+/// Extracts stable helper features from the full UnifiedTracking shape set.
+/// </summary>
+public static class FaceExpressionFeatureExtractor
+{
+    private const float SmileCornerPullWeight = 0.8f;
+    private const float SmileCornerSlantWeight = 0.2f;
+    private const float SadMouthStretchFallbackWeight = 0.35f;
+    private const float BrowLowererWeight = 0.75f;
+    private const float BrowPinchWeight = 0.25f;
+    private const float BrowOuterUpWeight = 0.6f;
+    private const float BrowInnerUpWeight = 0.4f;
+    private const float MouthOpenJawWeight = 0.5f;
+    private const float MouthOpenLipWeight = 0.25f;
+
+    public static FaceExpressionFeatureVector Extract(UnifiedTrackingData data)
+    {
+        var jawOpen = W(data, UnifiedExpressions.JawOpen);
+
+        return new FaceExpressionFeatureVector
+        {
+            Smile = Avg(
+                W(data, UnifiedExpressions.MouthCornerPullLeft) * SmileCornerPullWeight +
+                W(data, UnifiedExpressions.MouthCornerSlantLeft) * SmileCornerSlantWeight,
+                W(data, UnifiedExpressions.MouthCornerPullRight) * SmileCornerPullWeight +
+                W(data, UnifiedExpressions.MouthCornerSlantRight) * SmileCornerSlantWeight),
+
+            SadMouth = Avg(
+                Max(W(data, UnifiedExpressions.MouthFrownLeft), W(data, UnifiedExpressions.MouthStretchLeft) * SadMouthStretchFallbackWeight),
+                Max(W(data, UnifiedExpressions.MouthFrownRight), W(data, UnifiedExpressions.MouthStretchRight) * SadMouthStretchFallbackWeight)),
+
+            BrowDown = Avg(
+                W(data, UnifiedExpressions.BrowLowererLeft) * BrowLowererWeight +
+                W(data, UnifiedExpressions.BrowPinchLeft) * BrowPinchWeight,
+                W(data, UnifiedExpressions.BrowLowererRight) * BrowLowererWeight +
+                W(data, UnifiedExpressions.BrowPinchRight) * BrowPinchWeight),
+
+            BrowUp = Avg(
+                W(data, UnifiedExpressions.BrowOuterUpLeft) * BrowOuterUpWeight +
+                W(data, UnifiedExpressions.BrowInnerUpLeft) * BrowInnerUpWeight,
+                W(data, UnifiedExpressions.BrowOuterUpRight) * BrowOuterUpWeight +
+                W(data, UnifiedExpressions.BrowInnerUpRight) * BrowInnerUpWeight),
+
+            BrowInnerUp = Avg(
+                W(data, UnifiedExpressions.BrowInnerUpLeft),
+                W(data, UnifiedExpressions.BrowInnerUpRight)),
+
+            EyeWide = Avg(
+                W(data, UnifiedExpressions.EyeWideLeft),
+                W(data, UnifiedExpressions.EyeWideRight)),
+
+            EyeSquint = Avg(
+                W(data, UnifiedExpressions.EyeSquintLeft),
+                W(data, UnifiedExpressions.EyeSquintRight)),
+
+            CheekSquint = Avg(
+                W(data, UnifiedExpressions.CheekSquintLeft),
+                W(data, UnifiedExpressions.CheekSquintRight)),
+
+            JawOpen = jawOpen,
+
+            MouthOpen = Math.Clamp(
+                jawOpen * MouthOpenJawWeight +
+                Avg(
+                    W(data, UnifiedExpressions.MouthUpperUpLeft) + W(data, UnifiedExpressions.MouthLowerDownLeft),
+                    W(data, UnifiedExpressions.MouthUpperUpRight) + W(data, UnifiedExpressions.MouthLowerDownRight)) * MouthOpenLipWeight,
+                0f,
+                1f),
+
+            MouthPress = Avg(
+                W(data, UnifiedExpressions.MouthPressLeft),
+                W(data, UnifiedExpressions.MouthPressRight)),
+
+            MouthTightener = Avg(
+                W(data, UnifiedExpressions.MouthTightenerLeft),
+                W(data, UnifiedExpressions.MouthTightenerRight)),
+
+            NoseSneer = Avg(
+                W(data, UnifiedExpressions.NoseSneerLeft),
+                W(data, UnifiedExpressions.NoseSneerRight)),
+        };
+    }
+
+    private static float W(UnifiedTrackingData data, UnifiedExpressions shape)
+    {
+        // Modules may produce invalid floats; keep the helper output bounded and deterministic.
+        var value = data.Shapes[(int)shape].Weight;
+        return float.IsNaN(value) || float.IsInfinity(value) ? 0f : Math.Clamp(value, 0f, 1f);
+    }
+
+    private static float Avg(float a, float b) => (a + b) * 0.5f;
+
+    private static float Max(float a, float b) => Math.Max(a, b);
+}

--- a/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionOscParameters.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionOscParameters.cs
@@ -1,0 +1,51 @@
+using VRCFaceTracking.Core.Contracts;
+using VRCFaceTracking.Core.OSC.DataTypes;
+
+namespace VRCFaceTracking.Core.Params.Expressions;
+
+/// <summary>
+/// Registers the optional face expression helper OSC parameters.
+/// </summary>
+public static class FaceExpressionOscParameters
+{
+    public static readonly Parameter[] Parameters =
+    {
+        new FaceExpressionOscParameterPair(),
+    };
+}
+
+/// <summary>
+/// Exposes the current helper expression index and power as OSC parameters.
+/// </summary>
+public sealed class FaceExpressionOscParameterPair : Parameter
+{
+    private readonly Parameter[] _parameters =
+    {
+        new BaseParam<int>("v2/FaceExpressionIndex", _ => GetIndex()),
+        new BaseParam<float>("v2/FaceExpressionPower", _ => GetPower()),
+    };
+
+    public override Parameter[] ResetParam(IParameterDefinition[] newParams)
+    {
+        return _parameters.SelectMany(parameter => parameter.ResetParam(newParams)).ToArray();
+    }
+
+    public override (string, Parameter)[] GetParamNames()
+    {
+        return _parameters.SelectMany(parameter => parameter.GetParamNames()).ToArray();
+    }
+
+    private static int GetIndex()
+    {
+        var snapshot = FaceExpressionOscRuntime.GetSnapshot();
+        return snapshot.Enabled ? snapshot.CurrentResult.Index : 0;
+    }
+
+    private static float GetPower()
+    {
+        var snapshot = FaceExpressionOscRuntime.GetSnapshot();
+        return snapshot.Enabled
+            ? MathF.Round(Math.Clamp(snapshot.CurrentResult.Power, 0f, 1f), 3)
+            : 0f;
+    }
+}

--- a/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionOscRuntime.cs
+++ b/VRCFaceTracking.Core/Params/Expressions/FaceExpression/FaceExpressionOscRuntime.cs
@@ -1,0 +1,299 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using VRCFaceTracking.Core.Params.Data;
+using VRCFaceTracking.Core.Params.Data.Mutation;
+
+namespace VRCFaceTracking.Core.Params.Expressions;
+
+/// <summary>
+/// Thread-safe read model used by OSC parameter getters.
+/// </summary>
+public readonly record struct FaceExpressionRuntimeSnapshot(bool Enabled, FaceExpressionResult CurrentResult);
+
+/// <summary>
+/// Owns calibration capture, classification, and runtime state for the helper OSC output.
+/// </summary>
+public static class FaceExpressionOscRuntime
+{
+    private const float CalibrationDurationSeconds = 1f;
+    private const float HoldTimeSeconds = 0.2f;
+    private const float SwitchMargin = 0.08f;
+
+    private static readonly object Lock = new();
+
+    private static FaceExpressionOscOutput? _owner;
+    private static bool _enabled;
+    private static bool _saveRequested;
+    private static FaceExpressionResult _currentResult = new(FaceExpression.Neutral, 0, 0f);
+    private static FaceExpression _candidateFaceExpression = FaceExpression.Neutral;
+    private static long _candidateSinceTimestamp;
+    private static CalibrationSession? _calibrationSession;
+
+    public static void Register(FaceExpressionOscOutput owner)
+    {
+        lock (Lock)
+        {
+            _owner = owner;
+        }
+    }
+
+    public static void SetDisabled()
+    {
+        lock (Lock)
+        {
+            SetDisabledUnderLock();
+            _calibrationSession = null;
+        }
+    }
+
+    public static FaceExpressionRuntimeSnapshot GetSnapshot()
+    {
+        lock (Lock)
+        {
+            var ownerEnabled = _owner?.IsActive == true;
+            var mutatorEnabled = UnifiedTracking.Mutator?.Enabled == true;
+            if (!_enabled || !ownerEnabled || !mutatorEnabled)
+            {
+                return new FaceExpressionRuntimeSnapshot(false, new FaceExpressionResult(FaceExpression.Neutral, 0, 0f));
+            }
+
+            return new FaceExpressionRuntimeSnapshot(_enabled, _currentResult);
+        }
+    }
+
+    public static void Update(UnifiedTrackingData data, FaceExpressionOscOutput owner)
+    {
+        FaceExpressionOscOutput? ownerToSave = null;
+
+        lock (Lock)
+        {
+            _owner = owner;
+            if (!owner.IsActive)
+            {
+                SetDisabledUnderLock();
+                _calibrationSession = null;
+                if (ConsumeSaveRequestedUnderLock())
+                {
+                    ownerToSave = owner;
+                }
+            }
+            else
+            {
+                var calibration = owner.Calibration;
+                var rawFeatures = FaceExpressionFeatureExtractor.Extract(data);
+
+                // Calibration and classification share the same extracted feature vector for this frame.
+                ProcessCalibrationUnderLock(rawFeatures);
+
+                if (!calibration.IsReadyForFaceExpressionOsc())
+                {
+                    SetDisabledUnderLock();
+                    if (ConsumeSaveRequestedUnderLock())
+                    {
+                        ownerToSave = owner;
+                    }
+                }
+                else
+                {
+                    _enabled = true;
+                    var scores = FaceExpressionClassifier.GetReferenceScores(rawFeatures, calibration);
+
+                    var candidate = FaceExpressionClassifier.Classify(
+                        scores,
+                        owner.joyActivationThreshold,
+                        owner.angryActivationThreshold,
+                        owner.sadActivationThreshold,
+                        owner.surpriseActivationThreshold);
+                    _currentResult = ApplySwitchRulesUnderLock(candidate, scores);
+
+                    if (ConsumeSaveRequestedUnderLock())
+                    {
+                        ownerToSave = owner;
+                    }
+                }
+            }
+        }
+
+        ownerToSave?.RequestSave();
+    }
+
+    public static void BeginCalibration(FaceExpression expression)
+    {
+        lock (Lock)
+        {
+            if (_owner == null)
+            {
+                return;
+            }
+
+            _owner.Calibration.EnsureDefaults();
+            _calibrationSession = new CalibrationSession(expression, CalibrationDurationSeconds);
+            _owner.Logger?.LogInformation("Starting face expression calibration: {expression}", expression);
+        }
+    }
+
+    public static void ResetCalibration()
+    {
+        lock (Lock)
+        {
+            _owner?.Calibration.Reset();
+            _calibrationSession = null;
+            SetDisabledUnderLock();
+            _owner?.RefreshCalibrationComponents();
+            _owner?.Logger?.LogInformation("Reset face expression calibration");
+        }
+    }
+
+    private static void SetDisabledUnderLock()
+    {
+        _enabled = false;
+        _candidateFaceExpression = FaceExpression.Neutral;
+        _candidateSinceTimestamp = 0;
+        _currentResult = new FaceExpressionResult(FaceExpression.Neutral, 0, 0f);
+    }
+
+    private static FaceExpressionResult ApplySwitchRulesUnderLock(FaceExpressionResult candidate, FaceExpressionRawScores scores)
+    {
+        // Hold and margin prevent rapid label flicker when multiple templates score similarly.
+        if (_owner == null)
+        {
+            return new FaceExpressionResult(FaceExpression.Neutral, 0, 0f);
+        }
+
+        if (candidate.FaceExpression == _currentResult.FaceExpression)
+        {
+            _candidateFaceExpression = candidate.FaceExpression;
+            _candidateSinceTimestamp = Stopwatch.GetTimestamp();
+            return candidate;
+        }
+
+        if (!CanSwitchUnderLock(candidate.FaceExpression, scores))
+        {
+            return BuildResultForFaceExpression(_currentResult.FaceExpression, scores);
+        }
+
+        var now = Stopwatch.GetTimestamp();
+        if (_candidateFaceExpression != candidate.FaceExpression)
+        {
+            _candidateFaceExpression = candidate.FaceExpression;
+            _candidateSinceTimestamp = now;
+            return BuildResultForFaceExpression(_currentResult.FaceExpression, scores);
+        }
+
+        var elapsedSeconds = (now - _candidateSinceTimestamp) / (double)Stopwatch.Frequency;
+        if (elapsedSeconds < HoldTimeSeconds)
+        {
+            return BuildResultForFaceExpression(_currentResult.FaceExpression, scores);
+        }
+
+        if (_owner.debugLogging)
+        {
+            _owner.Logger?.LogDebug("Face expression classified {expression} with power {power}", candidate.FaceExpression, candidate.Power);
+        }
+
+        return candidate;
+    }
+
+    private static bool CanSwitchUnderLock(FaceExpression candidateFaceExpression, FaceExpressionRawScores scores)
+    {
+        if (_owner == null || candidateFaceExpression == FaceExpression.Neutral || _currentResult.FaceExpression == FaceExpression.Neutral)
+        {
+            return true;
+        }
+
+        var candidateScore = FaceExpressionClassifier.GetScoreForFaceExpression(scores, candidateFaceExpression);
+        var currentScore = FaceExpressionClassifier.GetScoreForFaceExpression(scores, _currentResult.FaceExpression);
+
+        return candidateScore >= currentScore + SwitchMargin;
+    }
+
+    private static FaceExpressionResult BuildResultForFaceExpression(FaceExpression expression, FaceExpressionRawScores scores)
+    {
+        var score = FaceExpressionClassifier.GetScoreForFaceExpression(scores, expression);
+        return new FaceExpressionResult(expression, (int)expression, Math.Clamp(score, 0f, 1f));
+    }
+
+    private static void ProcessCalibrationUnderLock(FaceExpressionFeatureVector rawFeatures)
+    {
+        // Accumulate a short sample window so templates are less sensitive to single-frame noise.
+        if (_owner == null || _calibrationSession == null)
+        {
+            return;
+        }
+
+        _calibrationSession.FeatureSum.Add(rawFeatures);
+        _calibrationSession.SampleCount++;
+
+        var elapsedSeconds = (Stopwatch.GetTimestamp() - _calibrationSession.StartTimestamp) / (double)Stopwatch.Frequency;
+        if (elapsedSeconds < _calibrationSession.DurationSeconds)
+        {
+            return;
+        }
+
+        CompleteCalibrationUnderLock(_calibrationSession);
+        _calibrationSession = null;
+        _saveRequested = true;
+    }
+
+    private static void CompleteCalibrationUnderLock(CalibrationSession session)
+    {
+        if (_owner == null)
+        {
+            return;
+        }
+
+        if (session.SampleCount <= 0)
+        {
+            _owner.Logger?.LogWarning("Face expression calibration completed without samples: {expression}", session.FaceExpression);
+            return;
+        }
+
+        if (session.FaceExpression == FaceExpression.Neutral)
+        {
+            _owner.Calibration.NeutralBaseline = session.FeatureSum.Divide(session.SampleCount);
+            _owner.Calibration.HasNeutralBaseline = true;
+            _owner.RefreshCalibrationComponents();
+            _owner.Logger?.LogInformation("Completed face expression calibration: Neutral");
+            return;
+        }
+
+        var reference = session.FeatureSum.Divide(session.SampleCount);
+        _owner.Calibration.SetRawReference(session.FaceExpression, reference, session.SampleCount);
+        _owner.RefreshCalibrationComponents();
+        _owner.Logger?.LogInformation(
+            "Completed face expression calibration: {expression}, reference samples = {samples}",
+            session.FaceExpression,
+            session.SampleCount);
+    }
+
+    private static bool ConsumeSaveRequestedUnderLock()
+    {
+        if (!_saveRequested)
+        {
+            return false;
+        }
+
+        _saveRequested = false;
+        return true;
+    }
+
+    private sealed class CalibrationSession
+    {
+        public CalibrationSession(FaceExpression expression, float durationSeconds)
+        {
+            FaceExpression = expression;
+            DurationSeconds = durationSeconds;
+            StartTimestamp = Stopwatch.GetTimestamp();
+        }
+
+        public FaceExpression FaceExpression { get; }
+
+        public float DurationSeconds { get; }
+
+        public long StartTimestamp { get; }
+
+        public int SampleCount { get; set; }
+
+        public FaceExpressionFeatureVector FeatureSum;
+    }
+}

--- a/VRCFaceTracking.Core/UnifiedTracking.cs
+++ b/VRCFaceTracking.Core/UnifiedTracking.cs
@@ -53,7 +53,7 @@ namespace VRCFaceTracking
         /// <summary> 
         /// The collection of EVERY possible output parameter
         /// </summary>
-        public static readonly Parameter[] AllParameters = AllParameters_v2.Concat(AllParameters_v1).Concat(HeadParameters).ToArray();
+        public static readonly Parameter[] AllParameters = AllParameters_v2.Concat(FaceExpressionOscParameters.Parameters).Concat(AllParameters_v1).Concat(HeadParameters).ToArray();
 #pragma warning restore CS0618
 
         /// <summary>

--- a/VRCFaceTracking/Helpers/ComponentSelection.cs
+++ b/VRCFaceTracking/Helpers/ComponentSelection.cs
@@ -17,6 +17,9 @@ public class ComponentTemplateSelector : DataTemplateSelector
     public DataTemplate SliderTemplate { get; set; }
     public DataTemplate ButtonTemplate { get; set; }
     public DataTemplate RangeTemplate { get; set; }
+    public DataTemplate InfoTemplate { get; set; }
+    public DataTemplate StatusTemplate { get; set; }
+    public DataTemplate StatusActionTemplate { get; set; }
 
     protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
     {
@@ -30,6 +33,12 @@ public class ComponentTemplateSelector : DataTemplateSelector
             };
         if (item is MutationRangeProperty)
             return RangeTemplate;
+        if (item is MutationInfo)
+            return InfoTemplate;
+        if (item is MutationStatus)
+            return StatusTemplate;
+        if (item is MutationStatusAction)
+            return StatusActionTemplate;
         if (item is MutationAction)
             return ButtonTemplate;
 

--- a/VRCFaceTracking/Services/DispatcherService.cs
+++ b/VRCFaceTracking/Services/DispatcherService.cs
@@ -5,5 +5,45 @@ namespace VRCFaceTracking.Services;
 // Simple service to invoke actions on the UI thread from the Core project.
 public class DispatcherService : IDispatcherService
 {
-    public void Run(Action action) => App.MainWindow.DispatcherQueue?.TryEnqueue(action.Invoke);
+    public void Run(Action action)
+    {
+        var dispatcher = App.MainWindow.DispatcherQueue;
+        if (dispatcher == null || dispatcher.HasThreadAccess)
+        {
+            action();
+            return;
+        }
+
+        dispatcher.TryEnqueue(action.Invoke);
+    }
+
+    public Task RunAsync(Action action)
+    {
+        // Initialization needs to wait until mutation UI objects are created on the UI thread.
+        var dispatcher = App.MainWindow.DispatcherQueue;
+        if (dispatcher == null || dispatcher.HasThreadAccess)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        var completion = new TaskCompletionSource<object?>();
+        if (!dispatcher.TryEnqueue(() =>
+            {
+                try
+                {
+                    action();
+                    completion.SetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            }))
+        {
+            completion.SetException(new InvalidOperationException("Failed to enqueue action on the UI dispatcher."));
+        }
+
+        return completion.Task;
+    }
 }

--- a/VRCFaceTracking/Views/MutatorPage.xaml
+++ b/VRCFaceTracking/Views/MutatorPage.xaml
@@ -99,7 +99,51 @@
                         <ColumnDefinition Width="6*" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Text="{Binding Name}" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                    <Button Content="{Binding Name}" MinWidth="0" Command="{Binding}" Margin="0" HorizontalAlignment="Right" Grid.Column="2"/>
+                    <Button Content="{Binding ButtonText}" MinWidth="0" Command="{Binding}" Margin="0" HorizontalAlignment="Right" Grid.Column="2"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="InfoTemplate">
+            <Border Background="#08ffffff"
+                    CornerRadius="2"
+                    Padding="20,10,20,10"
+                    Margin="0,1,0,1">
+                <TextBlock Text="{Binding Name}" Foreground="LightGray" TextWrapping="Wrap"/>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="StatusTemplate">
+            <Border Background="#08ffffff"
+                    CornerRadius="2"
+                    Padding="20,10,20,10"
+                    Margin="0,1,0,1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="5*" />
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="6*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="{Binding Name}" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                    <TextBlock Text="{Binding Value}" TextWrapping="Wrap" VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="2"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="StatusActionTemplate">
+            <Border Background="#08ffffff"
+                    CornerRadius="2"
+                    Padding="20,10,20,10"
+                    Margin="0,1,0,1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="5*" />
+                        <ColumnDefinition Width="2*"/>
+                        <ColumnDefinition Width="5*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="{Binding Name}" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                    <TextBlock Text="{Binding Status}" TextWrapping="Wrap" VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Margin="0,0,20,0"/>
+                    <Button Content="{Binding ButtonText}" MinWidth="0" Command="{Binding}" Margin="0" HorizontalAlignment="Right" Grid.Column="2"/>
                 </Grid>
             </Border>
         </DataTemplate>
@@ -140,6 +184,9 @@
                                           TextInputTemplate="{StaticResource TextInputTemplate}"
                                           ButtonTemplate="{StaticResource ButtonTemplate}"
                                           RangeTemplate="{StaticResource RangeTemplate}"
+                                          InfoTemplate="{StaticResource InfoTemplate}"
+                                          StatusTemplate="{StaticResource StatusTemplate}"
+                                          StatusActionTemplate="{StaticResource StatusActionTemplate}"
                                           SliderTemplate="{StaticResource SliderTemplate}"/>
     </Page.Resources>
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/1e64b452-f259-46e1-86e5-28381f9a2127

## Summary

This PR adds an optional Core-side OSC helper that classifies calibrated facial expression patterns from Unified Expressions and exposes the result as avatar parameters.

It is intended as an opt-in avatar helper output built from the user's calibrated facial expression templates.

## Why calibration is required

This helper uses calibration instead of a fixed rule-based mapping because face tracking behavior and intended avatar expressions can vary by user and avatar. Calibration lets the user define which facial pattern should map to each helper expression, instead of assuming one universal expression mapping.

## What changed

- Added a `Face Expression OSC Output` postprocessor mutation.
- Added helper OSC parameters:
  - `/avatar/parameters/v2/FaceExpressionIndex`
  - `/avatar/parameters/v2/FaceExpressionPower`
- Added calibration for:
  - Neutral
  - Joy
  - Angry
  - Sad
  - Surprise
- Added per-expression activation thresholds for Joy, Angry, Sad, and Surprise.
- Added saved calibration data, status rows, calibration buttons, and reset controls in the mutation UI.
- Added template-based scoring from a reduced Unified Expressions feature vector.
- Added hold/margin switching rules to reduce rapid expression flicker.
- Kept the helper disabled until Neutral, Joy, Angry, Sad, and Surprise are all calibrated.

## Behavior

Expression index values are:

- `0` = Neutral
- `1` = Joy
- `2` = Angry
- `3` = Sad
- `4` = Surprise

## Supporting changes

This PR also includes mutation UI infrastructure changes needed by the new calibration controls.

Mutation UI components are now created and refreshed through the UI dispatcher so stateful mutation controls, such as calibration status and button enabled/text updates, are marshalled back to the UI thread.

Mutation loading is now awaitable during startup, and each mutation is initialized before it is added to the active mutation collection. This avoids OSC updates observing partially loaded or uninitialized mutations during startup.

## Notes

The helper parameters currently use `v2/FaceExpressionIndex` and `v2/FaceExpressionPower`. I would appreciate feedback on whether these names fit the existing v2 parameter naming scheme, or if a different naming convention would be preferred.

This PR extends the mutation UI support layer because the calibration workflow needs to display current calibration state, button text, and enabled/disabled state dynamically. I kept the new components generic (`MutationInfo`, `MutationStatus`, `MutationStatusAction`) instead of making them face-expression-specific, and would appreciate feedback on whether this is the right level of abstraction for the project.

Related to #358.
